### PR TITLE
Allocates AST with arena allocator and makes AST operations more generic over pointer type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ googletest-prefix/
 build/
 compile_commands.json
 *.a
+.cache
 src/anf-defunctionalization

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,7 @@ file(
     test/lexer.cpp
     test/parser.cpp
     test/rename.cpp
+    test/arena.cpp
 )
 
 add_executable(lambcalc ${SOURCES})

--- a/include/anf.h
+++ b/include/anf.h
@@ -104,8 +104,8 @@ struct Exp : public std::variant<HaltExp, FunExp, JoinExp, JumpExp, AppExp,
 
 void resetCounter();
 std::unique_ptr<Exp> make(Exp &&exp);
-std::unique_ptr<Exp> convert(ast::Exp &exp);
-std::unique_ptr<Exp> convertDefunc(ast::Exp &root);
+std::unique_ptr<Exp> convert(ast::Exp<> &exp);
+std::unique_ptr<Exp> convertDefunc(ast::Exp<> &root);
 
 } // namespace anf
 } // namespace lambcalc

--- a/include/anf.h
+++ b/include/anf.h
@@ -105,7 +105,8 @@ struct Exp : public std::variant<HaltExp, FunExp, JoinExp, JumpExp, AppExp,
 void resetCounter();
 std::unique_ptr<Exp> make(Exp &&exp);
 std::unique_ptr<Exp> convert(ast::Exp<> &exp);
-std::unique_ptr<Exp> convertDefunc(ast::Exp<> &root);
+template <template <class> class Ptr>
+std::unique_ptr<Exp> convertDefunc(ast::Exp<Ptr> &root);
 
 } // namespace anf
 } // namespace lambcalc

--- a/include/arena.h
+++ b/include/arena.h
@@ -1,27 +1,56 @@
 #ifndef ARENA_H
 #define ARENA_H
 
-#include <cassert>
 #include <cstddef>
 #include <cstdint>
+#include <new>
 
 namespace lambcalc {
 namespace arena {
 
-struct allocator {
-  char *begin;
-  char *end;
+class Allocator {
+  char *begin_;
+  char *end_;
+
+public:
+  Allocator(char *begin, char *end) : begin_(begin), end_(end) {}
+  constexpr Allocator(const Allocator &other) noexcept {
+    begin_ = other.begin_;
+    end_ = other.end_;
+  }
+
+  template <typename T> T *allocate(std::ptrdiff_t count = 1) {
+    std::ptrdiff_t size = sizeof(T);
+    std::ptrdiff_t pad =
+        -reinterpret_cast<std::uintptr_t>(begin_) & (alignof(T) - 1);
+    if (count >= (end_ - begin_ - pad) / size) {
+      throw std::bad_alloc();
+    }
+    void *ptr = begin_ + pad;
+    begin_ += pad + count * size;
+    return new (ptr) T[count]{};
+  }
 };
 
-template <typename T> T *allocate(allocator *alloc, std::ptrdiff_t count = 1) {
-  std::ptrdiff_t size = sizeof(T);
-  std::ptrdiff_t pad =
-      -reinterpret_cast<std::uintptr_t>(alloc->begin) & (alignof(T) - 1);
-  assert(count < (alloc->end - alloc->begin - pad) / size);
-  void *ptr = alloc->begin + pad;
-  alloc->begin += pad + count * size;
-  return new (ptr) T[count]{};
-}
+template <typename T> class TypedAllocator {
+  Allocator &allocator_;
+
+public:
+  using value_type = T;
+  explicit TypedAllocator(Allocator &allocator) : allocator_(allocator) {}
+  template <typename U>
+  explicit constexpr TypedAllocator(const TypedAllocator<U> &other) noexcept {
+    allocator_ = other.allocator_;
+  }
+  T *allocate(std::ptrdiff_t n = 1) { return allocator_.allocate<T>(n); }
+  void deallocate(T *, std::ptrdiff_t) noexcept {}
+  friend bool operator==(const TypedAllocator &a, const TypedAllocator &b) {
+    return &a.allocator_ == &b.allocator_;
+  }
+  friend bool operator!=(const TypedAllocator &a, const TypedAllocator &b) {
+    return !(a == b);
+  }
+};
 
 } // namespace arena
 } // namespace lambcalc

--- a/include/arena.h
+++ b/include/arena.h
@@ -10,12 +10,14 @@ namespace arena {
 
 class Allocator {
   char *begin_;
+  char *orig_;
   char *end_;
 
 public:
-  Allocator(char *begin, char *end) : begin_(begin), end_(end) {}
+  Allocator(char *begin, char *end) : begin_(begin), orig_(begin), end_(end) {}
   constexpr Allocator(const Allocator &other) noexcept {
     begin_ = other.begin_;
+    orig_ = other.orig_;
     end_ = other.end_;
   }
 
@@ -30,6 +32,8 @@ public:
     begin_ += pad + count * size;
     return new (ptr) T[count]{};
   }
+
+  void reset() { begin_ = orig_; }
 };
 
 template <typename T> class TypedAllocator {

--- a/include/arena.h
+++ b/include/arena.h
@@ -1,0 +1,29 @@
+#ifndef ARENA_H
+#define ARENA_H
+
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+
+namespace lambcalc {
+namespace arena {
+
+struct allocator {
+  char *begin;
+  char *end;
+};
+
+template <typename T> T *allocate(allocator *alloc, std::ptrdiff_t count = 1) {
+  std::ptrdiff_t size = sizeof(T);
+  std::ptrdiff_t pad =
+      -reinterpret_cast<std::uintptr_t>(alloc->begin) & (alignof(T) - 1);
+  assert(count < (alloc->end - alloc->begin - pad) / size);
+  void *ptr = alloc->begin + pad;
+  alloc->begin += pad + count * size;
+  return new (ptr) T[count]{};
+}
+
+} // namespace arena
+} // namespace lambcalc
+
+#endif

--- a/include/parser.h
+++ b/include/parser.h
@@ -3,7 +3,9 @@
 
 #include "ast.h"
 #include "lexer.h"
+#include <memory>
 #include <optional>
+#include <utility>
 
 namespace lambcalc {
 
@@ -18,24 +20,35 @@ public:
   virtual const char *what() const throw() { return reason_.c_str(); }
 };
 
+template <template <class> class Ptr = std::unique_ptr,
+          typename Allocator = std::allocator<ast::Exp<Ptr>>>
 class Parser {
+  Allocator &allocator_;
   Lexer &lexer_;
   Token currentToken_;
   std::optional<Token> peekToken_;
   std::unordered_map<ast::Bop, std::optional<std::pair<int, int>>> infixBp_;
 
-  std::unique_ptr<ast::Exp<>> parseFn();
-  std::unique_ptr<ast::Exp<>> parseIf();
-  std::unique_ptr<ast::Exp<>> parseParens();
-  std::unique_ptr<ast::Exp<>> parsePrimary();
-  std::unique_ptr<ast::Exp<>> parseBinOp(int minBP);
+  Ptr<ast::Exp<Ptr>> parseFn();
+  Ptr<ast::Exp<Ptr>> parseIf();
+  Ptr<ast::Exp<Ptr>> parseParens();
+  Ptr<ast::Exp<Ptr>> parsePrimary();
+  Ptr<ast::Exp<Ptr>> parseBinOp(int minBP);
+
+  Ptr<ast::Exp<Ptr>> make(ast::Exp<Ptr> &&exp) {
+    ast::Exp<Ptr> *ptr = allocator_.allocate(1);
+    std::allocator_traits<Allocator>::construct(allocator_, ptr,
+                                                std::move(exp));
+    Ptr<ast::Exp<Ptr>> ptr2(ptr);
+    return ptr2;
+  }
 
 public:
   Parser(
-      Lexer &lexer,
+      Allocator &allocator, Lexer &lexer,
       std::unordered_map<ast::Bop, std::optional<std::pair<int, int>>> infixBp)
-      : lexer_(lexer), currentToken_(Token::Eof), infixBp_(std::move(infixBp)) {
-  }
+      : allocator_(allocator), lexer_(lexer), currentToken_(Token::Eof),
+        infixBp_(std::move(infixBp)) {}
   Token getCurrentToken() { return currentToken_; }
   void nextToken() {
     if (peekToken_) {
@@ -49,7 +62,7 @@ public:
   Token peekToken() {
     return peekToken_ ? *peekToken_ : *(peekToken_ = lexer_.getToken());
   }
-  std::unique_ptr<ast::Exp<>> parseExpression();
+  Ptr<ast::Exp<Ptr>> parseExpression();
 };
 
 } // namespace lambcalc

--- a/include/parser.h
+++ b/include/parser.h
@@ -24,11 +24,11 @@ class Parser {
   std::optional<Token> peekToken_;
   std::unordered_map<ast::Bop, std::optional<std::pair<int, int>>> infixBp_;
 
-  std::unique_ptr<ast::Exp> parseFn();
-  std::unique_ptr<ast::Exp> parseIf();
-  std::unique_ptr<ast::Exp> parseParens();
-  std::unique_ptr<ast::Exp> parsePrimary();
-  std::unique_ptr<ast::Exp> parseBinOp(int minBP);
+  std::unique_ptr<ast::Exp<>> parseFn();
+  std::unique_ptr<ast::Exp<>> parseIf();
+  std::unique_ptr<ast::Exp<>> parseParens();
+  std::unique_ptr<ast::Exp<>> parsePrimary();
+  std::unique_ptr<ast::Exp<>> parseBinOp(int minBP);
 
 public:
   Parser(
@@ -49,7 +49,7 @@ public:
   Token peekToken() {
     return peekToken_ ? *peekToken_ : *(peekToken_ = lexer_.getToken());
   }
-  std::unique_ptr<ast::Exp> parseExpression();
+  std::unique_ptr<ast::Exp<>> parseExpression();
 };
 
 } // namespace lambcalc

--- a/include/rename.h
+++ b/include/rename.h
@@ -17,7 +17,7 @@ public:
   virtual const char *what() const throw() { return reason_.c_str(); }
 };
 
-void rename(ast::Exp &exp);
+void rename(ast::Exp<> &exp);
 
 } // namespace ast
 } // namespace lambcalc

--- a/include/rename.h
+++ b/include/rename.h
@@ -17,7 +17,7 @@ public:
   virtual const char *what() const throw() { return reason_.c_str(); }
 };
 
-void rename(ast::Exp<> &exp);
+template <template <class> class Ptr> void rename(ast::Exp<Ptr> &exp);
 
 } // namespace ast
 } // namespace lambcalc

--- a/include/utils.h
+++ b/include/utils.h
@@ -1,8 +1,11 @@
 #ifndef UTILS_H
 #define UTILS_H
 
+#include <algorithm>
 #include <deque>
 #include <vector>
+
+template <typename T> using raw_ptr = T *;
 
 /**
  * Literal class type that wraps a constant expression string.

--- a/include/visitor.h
+++ b/include/visitor.h
@@ -25,7 +25,7 @@ using FnTask = std::move_only_function<void(void)>;
 
 template <typename Exp, template <class> class Ptr = std::unique_ptr>
 struct WorklistTask : std::variant<NodeTask<Exp, Ptr>, FnTask> {
-  using std::variant<NodeTask<Exp>, FnTask>::variant;
+  using std::variant<NodeTask<Exp, Ptr>, FnTask>::variant;
   explicit WorklistTask(Ptr<Exp> *parentLink)
       : WorklistTask(std::in_place_index<0>, parentLink, **parentLink) {}
 };
@@ -61,9 +61,9 @@ public:
   void operator()(const IfExp<Ptr> &exp);
 };
 
-template <typename Visitor, Task T, template <class> class W,
+template <typename Visitor, typename T, template <class> class W,
           template <class> class Ptr = std::unique_ptr>
-  requires Worklist<W<T>, T>
+  requires(Worklist<W<T>, T>, Task<T, Ptr>)
 class WorklistVisitor : public Visitor {
   W<T> worklist;
 

--- a/include/visitor.h
+++ b/include/visitor.h
@@ -2,7 +2,6 @@
 #define VISITOR_H
 
 #include "anf.h"
-#include <stack>
 #include <variant>
 
 namespace lambcalc {

--- a/src/anf.cpp
+++ b/src/anf.cpp
@@ -120,14 +120,12 @@ Exp::~Exp() {
   }
 }
 
-struct KFrame;
-struct K2Frame;
-
-using K = std::vector<KFrame>;
-using K2 = std::vector<K2Frame>;
-
-struct K2_Lam1 {
-  K k;
+template <template <class> class Ptr> struct KFrame;
+template <template <class> class Ptr> struct K2Frame;
+template <template <class> class Ptr> using K = std::vector<KFrame<Ptr>>;
+template <template <class> class Ptr> using K2 = std::vector<K2Frame<Ptr>>;
+template <template <class> class Ptr> struct K2_Lam1 {
+  K<Ptr> k;
   std::string v;
 };
 
@@ -147,15 +145,15 @@ struct K2_Bop1 {
   Value x, y;
 };
 
-struct K2_If1 {
-  ast::Exp<> &t;
-  ast::Exp<> &f;
+template <template <class> class Ptr> struct K2_If1 {
+  ast::Exp<Ptr> &t;
+  ast::Exp<Ptr> &f;
   std::string j, p;
   Value c;
 };
 
-struct K2_If2 {
-  ast::Exp<> &f;
+template <template <class> class Ptr> struct K2_If2 {
+  ast::Exp<Ptr> &f;
   std::string j, p;
   Value c;
   std::unique_ptr<Exp> rest;
@@ -168,21 +166,23 @@ struct K2_If3 {
   std::unique_ptr<Exp> rest;
 };
 
-struct K2Frame : public std::variant<K2_Lam1, K2_Lam2, K2_App1, K2_Bop1, K2_If1,
-                                     K2_If2, K2_If3> {
-  using variant::variant;
+template <template <class> class Ptr>
+struct K2Frame : public std::variant<K2_Lam1<Ptr>, K2_Lam2, K2_App1, K2_Bop1,
+                                     K2_If1<Ptr>, K2_If2<Ptr>, K2_If3> {
+  using std::variant<K2_Lam1<Ptr>, K2_Lam2, K2_App1, K2_Bop1, K2_If1<Ptr>,
+                     K2_If2<Ptr>, K2_If3>::variant;
 };
 
-struct K_App1 {
-  ast::Exp<> &x;
+template <template <class> class Ptr> struct K_App1 {
+  ast::Exp<Ptr> &x;
 };
 
 struct K_App2 {
   Value f;
 };
 
-struct K_Bop1 {
-  ast::Exp<> &y;
+template <template <class> class Ptr> struct K_Bop1 {
+  ast::Exp<Ptr> &y;
   ast::Bop bop;
 };
 
@@ -191,28 +191,31 @@ struct K_Bop2 {
   ast::Bop bop;
 };
 
-struct K_If1 {
-  ast::Exp<> &t;
-  ast::Exp<> &f;
+template <template <class> class Ptr> struct K_If1 {
+  ast::Exp<Ptr> &t;
+  ast::Exp<Ptr> &f;
 };
 
 struct K_If2 {
   std::string j;
 };
 
-struct KFrame
-    : public std::variant<K_App1, K_App2, K_Bop1, K_Bop2, K_If1, K_If2> {
-  using variant::variant;
+template <template <class> class Ptr>
+struct KFrame : public std::variant<K_App1<Ptr>, K_App2, K_Bop1<Ptr>, K_Bop2,
+                                    K_If1<Ptr>, K_If2> {
+  using std::variant<K_App1<Ptr>, K_App2, K_Bop1<Ptr>, K_Bop2, K_If1<Ptr>,
+                     K_If2>::variant;
 };
 
-std::unique_ptr<Exp> convertDefunc(ast::Exp<> &root) {
+template <template <class> class Ptr>
+std::unique_ptr<Exp> convertDefunc(ast::Exp<Ptr> &root) {
   // Parameters for apply_k2, apply_k, and go normalized.
   // If two parameters for different functions have the same type,
   // they can share the same variable because tail calls destroy the stack.
-  ast::Exp<> *go_exp = &root;
+  ast::Exp<Ptr> *go_exp = &root;
   std::unique_ptr<Exp> k2_exp;
-  K k;
-  K2 k2;
+  K<Ptr> k;
+  K2<Ptr> k2;
   Value value;
 
   enum { APPLY_K2, APPLY_K, GO } dispatch = GO;
@@ -227,7 +230,7 @@ std::unique_ptr<Exp> convertDefunc(ast::Exp<> &root) {
       k2.pop_back();
       std::visit(
           overloaded{
-              [&](K2_Lam1 &frame) {
+              [&](K2_Lam1<Ptr> &frame) {
                 auto f = fresh();
                 k = std::move(frame.k);
                 value = VarValue{f};
@@ -254,16 +257,16 @@ std::unique_ptr<Exp> convertDefunc(ast::Exp<> &root) {
                                      .param2 = std::move(frame.y),
                                      .rest = std::move(k2_exp)});
               },
-              [&](K2_If1 &frame) {
+              [&](K2_If1<Ptr> &frame) {
                 go_exp = &frame.t;
-                k2.emplace_back(std::in_place_type<K2_If2>, frame.f, frame.j,
-                                std::move(frame.p), std::move(frame.c),
+                k2.emplace_back(std::in_place_type<K2_If2<Ptr>>, frame.f,
+                                frame.j, std::move(frame.p), std::move(frame.c),
                                 std::move(k2_exp));
                 k.clear();
                 k.emplace_back(std::in_place_type<K_If2>, frame.j);
                 dispatch = GO;
               },
-              [&](K2_If2 &frame) {
+              [&](K2_If2<Ptr> &frame) {
                 go_exp = &frame.f;
                 k2.emplace_back(std::in_place_type<K2_If3>, std::move(k2_exp),
                                 frame.j, std::move(frame.p), std::move(frame.c),
@@ -295,7 +298,7 @@ std::unique_ptr<Exp> convertDefunc(ast::Exp<> &root) {
       k.pop_back();
       std::visit(
           overloaded{
-              [&](K_App1 &frame) {
+              [&](K_App1<Ptr> &frame) {
                 go_exp = &frame.x;
                 k.emplace_back(std::in_place_type<K_App2>, std::move(value));
                 dispatch = GO;
@@ -314,7 +317,7 @@ std::unique_ptr<Exp> convertDefunc(ast::Exp<> &root) {
                                       }},
                            frame.f);
               },
-              [&](K_Bop1 &frame) {
+              [&](K_Bop1<Ptr> &frame) {
                 go_exp = &frame.y;
                 k.emplace_back(std::in_place_type<K_Bop2>, std::move(value),
                                frame.bop);
@@ -326,12 +329,12 @@ std::unique_ptr<Exp> convertDefunc(ast::Exp<> &root) {
                                 std::move(frame.x), std::move(value));
                 value = VarValue{r};
               },
-              [&](K_If1 &frame) {
+              [&](K_If1<Ptr> &frame) {
                 auto j = fresh();
                 auto p = fresh();
 
-                k2.emplace_back(std::in_place_type<K2_If1>, frame.t, frame.f,
-                                std::move(j), p, std::move(value));
+                k2.emplace_back(std::in_place_type<K2_If1<Ptr>>, frame.t,
+                                frame.f, std::move(j), p, std::move(value));
                 value = VarValue{p};
               },
               [&](K_If2 &frame) {
@@ -344,42 +347,47 @@ std::unique_ptr<Exp> convertDefunc(ast::Exp<> &root) {
       break;
     }
     case GO:
-      std::visit(
-          overloaded{
-              [&](ast::IntExp &exp) {
-                value = IntValue{exp.value};
-                dispatch = APPLY_K;
-              },
-              [&](ast::VarExp &exp) {
-                value = VarValue{exp.name};
-                dispatch = APPLY_K;
-              },
-              [&](ast::LamExp<std::unique_ptr> &exp) {
-                go_exp = exp.body.get();
-                K oldK;
-                k.swap(oldK);
-                k2.emplace_back(std::in_place_type<K2_Lam1>, std::move(oldK),
-                                exp.param);
-              },
-              [&](ast::AppExp<std::unique_ptr> &exp) {
-                go_exp = exp.fn.get();
-                k.emplace_back(std::in_place_type<K_App1>, *exp.arg);
-              },
-              [&](ast::BopExp<std::unique_ptr> &exp) {
-                go_exp = exp.arg1.get();
-                k.emplace_back(std::in_place_type<K_Bop1>, *exp.arg2, exp.bop);
-              },
-              [&](ast::IfExp<std::unique_ptr> &exp) {
-                go_exp = exp.cond.get();
-                k.emplace_back(std::in_place_type<K_If1>, *exp.then, *exp.els);
-              },
-          },
-          *go_exp);
+      std::visit(overloaded{
+                     [&](ast::IntExp &exp) {
+                       value = IntValue{exp.value};
+                       dispatch = APPLY_K;
+                     },
+                     [&](ast::VarExp &exp) {
+                       value = VarValue{exp.name};
+                       dispatch = APPLY_K;
+                     },
+                     [&](ast::LamExp<Ptr> &exp) {
+                       go_exp = &*exp.body;
+                       K<Ptr> oldK;
+                       k.swap(oldK);
+                       k2.emplace_back(std::in_place_type<K2_Lam1<Ptr>>,
+                                       std::move(oldK), exp.param);
+                     },
+                     [&](ast::AppExp<Ptr> &exp) {
+                       go_exp = &*exp.fn;
+                       k.emplace_back(std::in_place_type<K_App1<Ptr>>,
+                                      *exp.arg);
+                     },
+                     [&](ast::BopExp<Ptr> &exp) {
+                       go_exp = &*exp.arg1;
+                       k.emplace_back(std::in_place_type<K_Bop1<Ptr>>,
+                                      *exp.arg2, exp.bop);
+                     },
+                     [&](ast::IfExp<Ptr> &exp) {
+                       go_exp = &*exp.cond;
+                       k.emplace_back(std::in_place_type<K_If1<Ptr>>, *exp.then,
+                                      *exp.els);
+                     },
+                 },
+                 *go_exp);
       break;
     }
   }
   return nullptr;
 }
+
+template std::unique_ptr<Exp> convertDefunc(ast::Exp<std::unique_ptr> &root);
+template std::unique_ptr<Exp> convertDefunc(ast::Exp<raw_ptr> &root);
 
 std::string Exp::dump() {
   std::ostringstream out;

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -1,25 +1,26 @@
 #include "ast.h"
 #include "visitor.h"
+#include <memory>
 #include <queue>
 #include <sstream>
 
 namespace lambcalc {
 namespace ast {
 
-std::unique_ptr<Exp> make(Exp &&exp) {
-  return std::make_unique<Exp>(std::move(exp));
+std::unique_ptr<Exp<>> make(Exp<> &&exp) {
+  return std::make_unique<Exp<>>(std::move(exp));
 }
 
-std::string Exp::dump() {
+template <template <class> class Ptr> std::string Exp<Ptr>::dump() {
   std::ostringstream out;
   out << *this;
   return out.str();
 }
 
 struct DestructorVisitor
-    : WorklistVisitor<DefaultVisitor, DestructorTask<Exp>, std::queue> {};
+    : WorklistVisitor<DefaultVisitor, DestructorTask<Exp<>>, std::queue> {};
 
-Exp::~Exp() {
+template <template <class> class Ptr> Exp<Ptr>::~Exp() {
   DestructorVisitor visitor;
   auto &queue = visitor.getWorklist();
   std::visit(visitor, *this);
@@ -32,6 +33,8 @@ Exp::~Exp() {
     }
   }
 }
+
+template struct Exp<std::unique_ptr>;
 
 }; // namespace ast
 } // namespace lambcalc

--- a/src/convert.cpp
+++ b/src/convert.cpp
@@ -2,6 +2,7 @@
 #include "utils.h"
 #include "visitor.h"
 #include <cassert>
+#include <stack>
 
 namespace lambcalc {
 namespace convert {

--- a/src/hoist.cpp
+++ b/src/hoist.cpp
@@ -1,6 +1,7 @@
 #include "hoist.h"
 #include "utils.h"
 #include "visitor.h"
+#include <stack>
 
 namespace lambcalc {
 namespace anf {

--- a/src/lower.cpp
+++ b/src/lower.cpp
@@ -8,6 +8,7 @@
 #include "llvm/Transforms/Scalar/Reassociate.h"
 #include "llvm/Transforms/Scalar/SimplifyCFG.h"
 #include "llvm/Transforms/Utils/Mem2Reg.h"
+#include <stack>
 
 namespace lambcalc {
 namespace lower {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,11 +1,13 @@
 #include "KaleidoscopeJIT.h"
 #include "anf.h"
+#include "arena.h"
 #include "ast.h"
 #include "convert.h"
 #include "hoist.h"
 #include "lower.h"
 #include "parser.h"
 #include "rename.h"
+#include "utils.h"
 #include "llvm/Support/TargetSelect.h"
 #include <iostream>
 #include <memory>
@@ -22,6 +24,11 @@ const std::unordered_map<ast::Bop, std::optional<std::pair<int, int>>>
                    {ast::Bop::Times, {{3, 4}}}};
 
 int main() {
+  alignas(alignof(ast::Exp<raw_ptr>)) static char buf[1 << 28];
+  char *ptr = std::launder(buf);
+  arena::Allocator allocator(ptr, ptr + sizeof(buf) / sizeof(*buf));
+  arena::TypedAllocator<ast::Exp<raw_ptr>> typed_allocator(allocator);
+
   llvm::InitializeNativeTarget();
   llvm::InitializeNativeTargetAsmPrinter();
   llvm::InitializeNativeTargetAsmParser();
@@ -29,16 +36,17 @@ int main() {
   std::unique_ptr<llvm::orc::KaleidoscopeJIT> jit =
       ExitOnErr(llvm::orc::KaleidoscopeJIT::Create());
   Lexer lexer(std::cin);
-  std::allocator<ast::Exp<>> allocator;
-  Parser parser(allocator, lexer, defaultInfixBp);
+  Parser<raw_ptr, arena::TypedAllocator<ast::Exp<raw_ptr>>> parser(
+      typed_allocator, lexer, defaultInfixBp);
   while (true) {
+    allocator.reset();
     // If a peek token is already buffered, consume it.
     if (parser.getPeekToken() && *parser.getPeekToken() == Token::Semicolon) {
       parser.nextToken();
       continue;
     }
     std::cout << "> ";
-    std::unique_ptr<ast::Exp<>> exp;
+    ast::Exp<raw_ptr> *exp;
     try {
       // If it reads a semicolon token at the start, go back to
       // beginning to consume it.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,6 +8,7 @@
 #include "rename.h"
 #include "llvm/Support/TargetSelect.h"
 #include <iostream>
+#include <memory>
 
 using namespace lambcalc;
 
@@ -28,7 +29,8 @@ int main() {
   std::unique_ptr<llvm::orc::KaleidoscopeJIT> jit =
       ExitOnErr(llvm::orc::KaleidoscopeJIT::Create());
   Lexer lexer(std::cin);
-  Parser parser(lexer, defaultInfixBp);
+  std::allocator<ast::Exp<>> allocator;
+  Parser parser(allocator, lexer, defaultInfixBp);
   while (true) {
     // If a peek token is already buffered, consume it.
     if (parser.getPeekToken() && *parser.getPeekToken() == Token::Semicolon) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,7 +7,6 @@
 #include "parser.h"
 #include "rename.h"
 #include "llvm/Support/TargetSelect.h"
-#include "llvm/Target/TargetMachine.h"
 #include <iostream>
 
 using namespace lambcalc;
@@ -37,7 +36,7 @@ int main() {
       continue;
     }
     std::cout << "> ";
-    std::unique_ptr<ast::Exp> exp;
+    std::unique_ptr<ast::Exp<>> exp;
     try {
       // If it reads a semicolon token at the start, go back to
       // beginning to consume it.

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -16,7 +16,7 @@ static std::optional<ast::Bop> parseOp(const Token &token) {
   }
 }
 
-std::unique_ptr<ast::Exp> Parser::parseFn() {
+std::unique_ptr<ast::Exp<>> Parser::parseFn() {
   nextToken();
   assert(getCurrentToken() == Token::Identifier &&
          "Expected variable parameter");
@@ -28,7 +28,7 @@ std::unique_ptr<ast::Exp> Parser::parseFn() {
   return ast::make(ast::LamExp{std::move(param), std::move(body)});
 }
 
-std::unique_ptr<ast::Exp> Parser::parseIf() {
+std::unique_ptr<ast::Exp<>> Parser::parseIf() {
   auto cond = parseExpression();
   nextToken();
   assert(getCurrentToken() == Token::Then &&
@@ -42,14 +42,14 @@ std::unique_ptr<ast::Exp> Parser::parseIf() {
       ast::IfExp{std::move(cond), std::move(then), std::move(els)});
 }
 
-std::unique_ptr<ast::Exp> Parser::parseParens() {
+std::unique_ptr<ast::Exp<>> Parser::parseParens() {
   auto exp = parseExpression();
   nextToken();
   assert(getCurrentToken() == Token::RParen && "Expected right parenthesis");
   return exp;
 }
 
-std::unique_ptr<ast::Exp> Parser::parsePrimary() {
+std::unique_ptr<ast::Exp<>> Parser::parsePrimary() {
   switch (getCurrentToken()) {
   case Token::LParen:
     return parseParens();
@@ -70,9 +70,9 @@ std::unique_ptr<ast::Exp> Parser::parsePrimary() {
 
 constexpr int baseBP = 0;
 
-std::unique_ptr<ast::Exp> Parser::parseBinOp(int minBP) {
+std::unique_ptr<ast::Exp<>> Parser::parseBinOp(int minBP) {
   nextToken();
-  std::unique_ptr<ast::Exp> lhs = parsePrimary();
+  std::unique_ptr<ast::Exp<>> lhs = parsePrimary();
 
   int appLbp = 100, appRbp = 101;
   while (true) {
@@ -107,7 +107,7 @@ std::unique_ptr<ast::Exp> Parser::parseBinOp(int minBP) {
   }
 }
 
-std::unique_ptr<ast::Exp> Parser::parseExpression() {
+std::unique_ptr<ast::Exp<>> Parser::parseExpression() {
   return parseBinOp(baseBP);
 }
 

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1,5 +1,8 @@
 #include "parser.h"
+#include "arena.h"
+#include "utils.h"
 #include <cassert>
+#include <memory>
 
 namespace lambcalc {
 
@@ -16,7 +19,8 @@ static std::optional<ast::Bop> parseOp(const Token &token) {
   }
 }
 
-std::unique_ptr<ast::Exp<>> Parser::parseFn() {
+template <template <class> class Ptr, typename Allocator>
+Ptr<ast::Exp<Ptr>> Parser<Ptr, Allocator>::parseFn() {
   nextToken();
   assert(getCurrentToken() == Token::Identifier &&
          "Expected variable parameter");
@@ -25,10 +29,11 @@ std::unique_ptr<ast::Exp<>> Parser::parseFn() {
   assert(getCurrentToken() == Token::Arrow &&
          "Expected arrow after function parameter");
   auto body = parseExpression();
-  return ast::make(ast::LamExp{std::move(param), std::move(body)});
+  return make(ast::LamExp<Ptr>{std::move(param), std::move(body)});
 }
 
-std::unique_ptr<ast::Exp<>> Parser::parseIf() {
+template <template <class> class Ptr, typename Allocator>
+Ptr<ast::Exp<Ptr>> Parser<Ptr, Allocator>::parseIf() {
   auto cond = parseExpression();
   nextToken();
   assert(getCurrentToken() == Token::Then &&
@@ -38,29 +43,31 @@ std::unique_ptr<ast::Exp<>> Parser::parseIf() {
   assert(getCurrentToken() == Token::Else &&
          "Expected else after then expression");
   auto els = parseExpression();
-  return ast::make(
-      ast::IfExp{std::move(cond), std::move(then), std::move(els)});
+  return make(
+      ast::IfExp<Ptr>{std::move(cond), std::move(then), std::move(els)});
 }
 
-std::unique_ptr<ast::Exp<>> Parser::parseParens() {
+template <template <class> class Ptr, typename Allocator>
+Ptr<ast::Exp<Ptr>> Parser<Ptr, Allocator>::parseParens() {
   auto exp = parseExpression();
   nextToken();
   assert(getCurrentToken() == Token::RParen && "Expected right parenthesis");
   return exp;
 }
 
-std::unique_ptr<ast::Exp<>> Parser::parsePrimary() {
+template <template <class> class Ptr, typename Allocator>
+Ptr<ast::Exp<Ptr>> Parser<Ptr, Allocator>::parsePrimary() {
   switch (getCurrentToken()) {
   case Token::LParen:
     return parseParens();
   case Token::Number:
-    return ast::make(ast::IntExp{lexer_.getNumber()});
+    return make(ast::IntExp{lexer_.getNumber()});
   case Token::Fn:
     return parseFn();
   case Token::If:
     return parseIf();
   case Token::Identifier:
-    return ast::make(ast::VarExp{lexer_.getIdentifier()});
+    return make(ast::VarExp{lexer_.getIdentifier()});
   default:
     throw ParserException(
         "Invalid token: " + std::to_string(static_cast<int>(getCurrentToken())),
@@ -70,9 +77,10 @@ std::unique_ptr<ast::Exp<>> Parser::parsePrimary() {
 
 constexpr int baseBP = 0;
 
-std::unique_ptr<ast::Exp<>> Parser::parseBinOp(int minBP) {
+template <template <class> class Ptr, typename Allocator>
+Ptr<ast::Exp<Ptr>> Parser<Ptr, Allocator>::parseBinOp(int minBP) {
   nextToken();
-  std::unique_ptr<ast::Exp<>> lhs = parsePrimary();
+  Ptr<ast::Exp<Ptr>> lhs = parsePrimary();
 
   int appLbp = 100, appRbp = 101;
   while (true) {
@@ -88,7 +96,7 @@ std::unique_ptr<ast::Exp<>> Parser::parseBinOp(int minBP) {
 
         nextToken();
         auto rhs = parseBinOp(rbp);
-        lhs = ast::make(ast::BopExp{*bop, std::move(lhs), std::move(rhs)});
+        lhs = make(ast::BopExp<Ptr>{*bop, std::move(lhs), std::move(rhs)});
       } else {
         return lhs;
       }
@@ -100,15 +108,19 @@ std::unique_ptr<ast::Exp<>> Parser::parseBinOp(int minBP) {
       }
 
       auto rhs = parseBinOp(appRbp);
-      lhs = ast::make(ast::AppExp{std::move(lhs), std::move(rhs)});
+      lhs = make(ast::AppExp<Ptr>{std::move(lhs), std::move(rhs)});
     } else {
       return lhs;
     }
   }
 }
 
-std::unique_ptr<ast::Exp<>> Parser::parseExpression() {
+template <template <class> class Ptr, typename Allocator>
+Ptr<ast::Exp<Ptr>> Parser<Ptr, Allocator>::parseExpression() {
   return parseBinOp(baseBP);
 }
+
+template class Parser<std::unique_ptr, std::allocator<ast::Exp<>>>;
+template class Parser<raw_ptr, arena::TypedAllocator<ast::Exp<raw_ptr>>>;
 
 } // namespace lambcalc

--- a/src/rename.cpp
+++ b/src/rename.cpp
@@ -2,6 +2,7 @@
 #include "utils.h"
 #include "visitor.h"
 #include <memory>
+#include <stack>
 
 namespace lambcalc {
 namespace ast {

--- a/src/rename.cpp
+++ b/src/rename.cpp
@@ -58,8 +58,8 @@ template <template <class> class Ptr> void rename(ast::Exp<Ptr> &exp) {
   while (!worklist.empty()) {
     auto task = std::move(worklist.top());
     worklist.pop();
-    std::visit(overloaded{[&](NodeTask<Exp<>> &n) {
-                            Exp<> &exp = std::get<1>(n);
+    std::visit(overloaded{[&](NodeTask<Exp<Ptr>, Ptr> &n) {
+                            Exp<Ptr> &exp = std::get<1>(n);
                             std::visit(visitor, exp);
                           },
                           [](FnTask &f) { std::move(f)(); }},
@@ -68,6 +68,7 @@ template <template <class> class Ptr> void rename(ast::Exp<Ptr> &exp) {
 }
 
 template void rename(ast::Exp<std::unique_ptr> &);
+template void rename(ast::Exp<raw_ptr> &);
 
 } // namespace ast
 } // namespace lambcalc

--- a/src/visitor.cpp
+++ b/src/visitor.cpp
@@ -1,5 +1,6 @@
 #include "visitor.h"
 #include <utility>
+#include <variant>
 
 namespace lambcalc {
 
@@ -38,7 +39,8 @@ void print_optional(std::ostream &os, std::optional<T> opt) {
 
 namespace ast {
 
-std::ostream &operator<<(std::ostream &os, const Exp &exp) {
+template <template <class> class Ptr>
+std::ostream &operator<<(std::ostream &os, const Exp<Ptr> &exp) {
   std::visit(PrintExpVisitor(os), exp);
   return os;
 }

--- a/src/visitor.cpp
+++ b/src/visitor.cpp
@@ -1,4 +1,5 @@
 #include "visitor.h"
+#include "utils.h"
 #include <utility>
 #include <variant>
 
@@ -73,6 +74,7 @@ void PrintExpVisitor<Ptr>::operator()(const IfExp<Ptr> &exp) {
 }
 
 template class PrintExpVisitor<std::unique_ptr>;
+template class PrintExpVisitor<raw_ptr>;
 
 } // namespace ast
 

--- a/src/visitor.cpp
+++ b/src/visitor.cpp
@@ -41,26 +41,38 @@ namespace ast {
 
 template <template <class> class Ptr>
 std::ostream &operator<<(std::ostream &os, const Exp<Ptr> &exp) {
-  std::visit(PrintExpVisitor(os), exp);
+  std::visit(PrintExpVisitor<Ptr>(os), exp);
   return os;
 }
 
-void PrintExpVisitor::operator()(const IntExp &exp) { out_ << exp.value; }
-void PrintExpVisitor::operator()(const VarExp &exp) { out_ << exp.name; }
-void PrintExpVisitor::operator()(const LamExp &exp) {
+template <template <class> class Ptr>
+void PrintExpVisitor<Ptr>::operator()(const IntExp &exp) {
+  out_ << exp.value;
+}
+template <template <class> class Ptr>
+void PrintExpVisitor<Ptr>::operator()(const VarExp &exp) {
+  out_ << exp.name;
+}
+template <template <class> class Ptr>
+void PrintExpVisitor<Ptr>::operator()(const LamExp<Ptr> &exp) {
   out_ << "(fn " << exp.param << " => " << *exp.body << ")";
 }
-void PrintExpVisitor::operator()(const AppExp &exp) {
+template <template <class> class Ptr>
+void PrintExpVisitor<Ptr>::operator()(const AppExp<Ptr> &exp) {
   out_ << "(" << *exp.fn << " " << *exp.arg << ")";
 }
-void PrintExpVisitor::operator()(const BopExp &exp) {
+template <template <class> class Ptr>
+void PrintExpVisitor<Ptr>::operator()(const BopExp<Ptr> &exp) {
   out_ << "(" << *exp.arg1 << " " << binOpString(exp.bop) << " " << *exp.arg2
        << ")";
 }
-void PrintExpVisitor::operator()(const IfExp &exp) {
+template <template <class> class Ptr>
+void PrintExpVisitor<Ptr>::operator()(const IfExp<Ptr> &exp) {
   out_ << "(if " << *exp.cond << " then " << *exp.then << " else " << *exp.els
        << ")";
 }
+
+template class PrintExpVisitor<std::unique_ptr>;
 
 } // namespace ast
 

--- a/test/arena.cpp
+++ b/test/arena.cpp
@@ -13,14 +13,26 @@ TEST(Arena, Vector) {
   char *ptr = std::launder(buf);
   Allocator allocator(ptr, ptr + sizeof(buf) / sizeof(*buf));
   TypedAllocator<int> typed_allocator(allocator);
-  std::vector<int, TypedAllocator<int>> v(typed_allocator);
   std::vector<int> expected;
-  for (int i = 0; i <= 100; ++i) {
-    v.push_back(i);
-    expected.push_back(i);
+  {
+    std::vector<int, TypedAllocator<int>> v(typed_allocator);
+    for (int i = 0; i <= 100; ++i) {
+      v.push_back(i);
+      expected.push_back(i);
+    }
+    for (size_t i = 0; i < v.size(); ++i) {
+      EXPECT_EQ(v[i], expected[i]);
+    }
   }
-  for (size_t i = 0; i < v.size(); ++i) {
-    EXPECT_EQ(v[i], expected[i]);
+  allocator.reset();
+  {
+    std::vector<int, TypedAllocator<int>> v(typed_allocator);
+    for (int i = 0; i <= 100; ++i) {
+      v.push_back(i);
+    }
+    for (size_t i = 0; i < v.size(); ++i) {
+      EXPECT_EQ(v[i], expected[i]);
+    }
   }
 }
 

--- a/test/arena.cpp
+++ b/test/arena.cpp
@@ -1,0 +1,27 @@
+#include "arena.h"
+#include <cstddef>
+#include <gtest/gtest.h>
+#include <new>
+#include <vector>
+
+namespace lambcalc {
+
+using namespace arena;
+
+TEST(Arena, Vector) {
+  alignas(alignof(int)) char buf[2000];
+  char *ptr = std::launder(buf);
+  Allocator allocator(ptr, ptr + sizeof(buf) / sizeof(*buf));
+  TypedAllocator<int> typed_allocator(allocator);
+  std::vector<int, TypedAllocator<int>> v(typed_allocator);
+  std::vector<int> expected;
+  for (int i = 0; i <= 100; ++i) {
+    v.push_back(i);
+    expected.push_back(i);
+  }
+  for (size_t i = 0; i < v.size(); ++i) {
+    EXPECT_EQ(v[i], expected[i]);
+  }
+}
+
+} // namespace lambcalc

--- a/test/parser.cpp
+++ b/test/parser.cpp
@@ -11,8 +11,9 @@ const std::unordered_map<ast::Bop, std::optional<std::pair<int, int>>>
 
 TEST(Parser, ParsesOperators) {
   std::istringstream is(" (fn a => a + 1 + 2 * 3 * 4 + 5 ) ");
+  std::allocator<ast::Exp<>> allocator;
   Lexer lexer(is);
-  Parser parser(lexer, defaultInfixBp);
+  Parser parser(allocator, lexer, defaultInfixBp);
   auto exp = parser.parseExpression();
   std::string expected = "(fn a => (((a + 1) + ((2 * 3) * 4)) + 5))";
   EXPECT_EQ(exp->dump(), expected);
@@ -20,8 +21,9 @@ TEST(Parser, ParsesOperators) {
 
 TEST(Parser, ParsesApp) {
   std::istringstream is("a b c + d e f");
+  std::allocator<ast::Exp<>> allocator;
   Lexer lexer(is);
-  Parser parser(lexer, defaultInfixBp);
+  Parser parser(allocator, lexer, defaultInfixBp);
   auto exp = parser.parseExpression();
   std::string expected = "(((a b) c) + ((d e) f))";
   EXPECT_EQ(exp->dump(), expected);
@@ -29,8 +31,9 @@ TEST(Parser, ParsesApp) {
 
 TEST(Parser, ParseIfWithAppParens) {
   std::istringstream is("if x then x * f (x - 1) else 1");
+  std::allocator<ast::Exp<>> allocator;
   Lexer lexer(is);
-  Parser parser(lexer, defaultInfixBp);
+  Parser parser(allocator, lexer, defaultInfixBp);
   auto exp = parser.parseExpression();
   std::string expected = "(if x then (x * (f (x - 1))) else 1)";
   EXPECT_EQ(exp->dump(), expected);
@@ -40,8 +43,9 @@ TEST(Parser, ZCombinator) {
   std::istringstream is(
       "(fn g => (fn x => g (fn v => x x v)) (fn x => g (fn v => x x v))) (fn f "
       "=> fn x => if x then (if x - 1 then x * f (x - 1) else 1) else 1) 5");
+  std::allocator<ast::Exp<>> allocator;
   Lexer lexer(is);
-  Parser parser(lexer, defaultInfixBp);
+  Parser parser(allocator, lexer, defaultInfixBp);
   auto exp = parser.parseExpression();
   std::string expected =
       "(((fn g => ((fn x => (g (fn v => ((x x) v)))) (fn x => (g (fn v => ((x "


### PR DESCRIPTION
Allocating ASTs with the default allocator is unnecessary because they are only used briefly before being converted into ANF and destroyed. This PR changes the AST and operations on it to be agnostic to pointer types so it can work with both `std::unique_ptr` and `T*`. Then in the main program it allocates the AST using an arena allocator when parsing an expression. The AST doesn't have to be destructed after the JIT runs the result, instead the arena is reset.