### PR TITLE
Refactor std::string into symbols

### DIFF
--- a/include/anf.h
+++ b/include/anf.h
@@ -16,7 +16,7 @@ struct Value;
 struct Exp;
 
 using Cont = std::function<std::unique_ptr<Exp>(Value)>;
-using Var = std::string;
+using Var = Symbol;
 
 struct IntValue {
   int value;
@@ -32,7 +32,8 @@ struct GlobValue {
 
 struct Value : public std::variant<IntValue, VarValue, GlobValue> {
   using variant::variant;
-  friend std::ostream &operator<<(std::ostream &os, const Value &value);
+  friend void print(const SymbolTable &table, std::ostream &os,
+                    const Value &value);
 };
 
 struct HaltExp {
@@ -95,8 +96,8 @@ struct ProjExp {
 struct Exp : public std::variant<HaltExp, FunExp, JoinExp, JumpExp, AppExp,
                                  BopExp, IfExp, TupleExp, ProjExp> {
   using variant::variant;
-  friend std::ostream &operator<<(std::ostream &os, const Exp &exp);
-  std::string dump();
+  friend void print(const SymbolTable &table, std::ostream &os, const Exp &exp);
+  std::string dump(const SymbolTable &table);
   // Need to redefine the move constructor after defining the destructor :(
   Exp(Exp &&) = default;
   ~Exp();
@@ -104,9 +105,9 @@ struct Exp : public std::variant<HaltExp, FunExp, JoinExp, JumpExp, AppExp,
 
 void resetCounter();
 std::unique_ptr<Exp> make(Exp &&exp);
-std::unique_ptr<Exp> convert(ast::Exp<> &exp);
+std::unique_ptr<Exp> convert(SymbolTable &table, ast::Exp<> &exp);
 template <template <class> class Ptr>
-std::unique_ptr<Exp> convertDefunc(ast::Exp<Ptr> &root);
+std::unique_ptr<Exp> convertDefunc(SymbolTable &table, ast::Exp<Ptr> &root);
 
 } // namespace anf
 } // namespace lambcalc

--- a/include/ast.h
+++ b/include/ast.h
@@ -1,6 +1,7 @@
 #ifndef AST_H
 #define AST_H
 
+#include "symbol.h"
 #include <functional>
 #include <memory>
 #include <string>
@@ -20,11 +21,11 @@ struct IntExp {
 };
 
 struct VarExp {
-  std::string name;
+  Symbol name;
 };
 
 template <template <class> class Ptr> struct LamExp {
-  std::string param;
+  Symbol param;
   Ptr<Exp<Ptr>> body;
 };
 
@@ -58,8 +59,9 @@ struct Exp : public std::variant<IntExp, VarExp, LamExp<Ptr>, AppExp<Ptr>,
                      IfExp<Ptr>>::variant;
 
   template <template <class> class P>
-  friend std::ostream &operator<<(std::ostream &os, const Exp<P> &exp);
-  std::string dump();
+  friend void print(const SymbolTable &table, std::ostream &os,
+                    const Exp<P> &exp);
+  std::string dump(const SymbolTable &);
 
   // Need to redefine the move constructor after defining the destructor :(
   Exp(Exp<Ptr> &&) = default;
@@ -68,7 +70,8 @@ struct Exp : public std::variant<IntExp, VarExp, LamExp<Ptr>, AppExp<Ptr>,
 
 std::unique_ptr<Exp<>> make(Exp<> &&exp);
 std::unique_ptr<anf::Exp>
-convert(Exp<> &exp, std::function<std::unique_ptr<anf::Exp>(anf::Value)> k);
+convert(SymbolTable &table, Exp<> &exp,
+        std::function<std::unique_ptr<anf::Exp>(anf::Value)> k);
 
 } // namespace ast
 } // namespace lambcalc

--- a/include/convert.h
+++ b/include/convert.h
@@ -8,7 +8,8 @@ namespace lambcalc {
 namespace convert {
 
 std::set<anf::Var> freeVars(anf::Exp &exp);
-std::unique_ptr<anf::Exp> closureConvert(std::unique_ptr<anf::Exp> &&start);
+std::unique_ptr<anf::Exp> closureConvert(SymbolTable &table,
+                                         std::unique_ptr<anf::Exp> &&start);
 
 } // namespace convert
 } // namespace lambcalc

--- a/include/hoist.h
+++ b/include/hoist.h
@@ -19,7 +19,8 @@ struct Function {
   std::vector<Join> blocks;
 };
 
-std::vector<Function> hoist(std::unique_ptr<anf::Exp> &&exp);
+std::vector<Function> hoist(SymbolTable &table,
+                            std::unique_ptr<anf::Exp> &&exp);
 
 } // namespace anf
 } // namespace lambcalc

--- a/include/lexer.h
+++ b/include/lexer.h
@@ -1,7 +1,7 @@
 #ifndef LEXER_H
 #define LEXER_H
 
-#include <string>
+#include "symbol.h"
 
 namespace lambcalc {
 
@@ -23,15 +23,17 @@ enum class Token {
 };
 
 class Lexer {
+  SymbolTable &table_;
   std::istream &in_;
   int lastChar_;
-  std::string identifier_;
+  Symbol identifier_;
   int numberValue_;
 
 public:
-  explicit Lexer(std::istream &in) : in_(in), lastChar_(' '), numberValue_(0) {}
+  explicit Lexer(SymbolTable &table, std::istream &in)
+      : table_(table), in_(in), lastChar_(' '), numberValue_(0) {}
   Token getToken();
-  const std::string &getIdentifier() const { return identifier_; }
+  const Symbol &getIdentifier() const { return identifier_; }
   int getNumber() const { return numberValue_; }
 };
 

--- a/include/lower.h
+++ b/include/lower.h
@@ -18,8 +18,10 @@ extern std::unique_ptr<llvm::ModuleAnalysisManager> mam;
 extern std::unique_ptr<llvm::PassInstrumentationCallbacks> pic;
 extern std::unique_ptr<llvm::StandardInstrumentations> si;
 
-std::unique_ptr<llvm::Module> lower(std::vector<anf::Function> &&fns);
-std::unique_ptr<llvm::Module> lower(std::vector<anf::Function> &&fns,
+std::unique_ptr<llvm::Module> lower(const SymbolTable &table,
+                                    std::vector<anf::Function> &&fns);
+std::unique_ptr<llvm::Module> lower(const SymbolTable &table,
+                                    std::vector<anf::Function> &&fns,
                                     const llvm::DataLayout &layout);
 
 } // namespace lower

--- a/include/rename.h
+++ b/include/rename.h
@@ -17,7 +17,8 @@ public:
   virtual const char *what() const throw() { return reason_.c_str(); }
 };
 
-template <template <class> class Ptr> void rename(ast::Exp<Ptr> &exp);
+template <template <class> class Ptr>
+void rename(SymbolTable &table, ast::Exp<Ptr> &exp);
 
 } // namespace ast
 } // namespace lambcalc

--- a/include/symbol.h
+++ b/include/symbol.h
@@ -1,0 +1,32 @@
+#ifndef SYMBOL_H
+#define SYMBOL_H
+
+#include <string>
+#include <unordered_map>
+
+namespace lambcalc {
+
+using Symbol = size_t;
+
+class SymbolTable {
+  size_t counter_;
+  std::unordered_map<Symbol, std::string> symToStr_;
+  std::unordered_map<std::string, Symbol> strToSym_;
+
+public:
+  SymbolTable() : counter_(0) {};
+  Symbol lookup(const std::string &s) {
+    if (strToSym_.contains(s)) {
+      return strToSym_[s];
+    }
+    Symbol sym = counter_++;
+    strToSym_[s] = sym;
+    symToStr_[sym] = s;
+    return sym;
+  }
+  const std::string &lookup(Symbol sym) const { return symToStr_.at(sym); };
+};
+
+} // namespace lambcalc
+
+#endif // SYMBOL_H

--- a/include/visitor.h
+++ b/include/visitor.h
@@ -51,11 +51,13 @@ concept Task = requires(T task, Ptr<Exp<Ptr>> *parentLink) {
 };
 
 template <template <class> class Ptr> class PrintExpVisitor {
+  const SymbolTable &table_;
   std::ostream &out_;
 
 public:
-  explicit PrintExpVisitor(std::reference_wrapper<std::ostream> out)
-      : out_(out) {}
+  explicit PrintExpVisitor(const SymbolTable &table,
+                           std::reference_wrapper<std::ostream> out)
+      : table_(table), out_(out) {}
   void operator()(const IntExp &exp);
   void operator()(const VarExp &exp);
   void operator()(const LamExp<Ptr> &exp);
@@ -76,7 +78,7 @@ public:
   virtual void addWorklist(Ptr<Exp<Ptr>> *parentLink) {
     worklist.push(T(parentLink));
   }
-  virtual void addWorklist(const std::string &, Ptr<Exp<Ptr>> *parentLink) {
+  virtual void addWorklist(const Symbol &, Ptr<Exp<Ptr>> *parentLink) {
     addWorklist(parentLink);
   }
 
@@ -258,21 +260,25 @@ public:
 };
 
 class PrintValueVisitor {
+  const SymbolTable &table_;
   std::ostream &out_;
 
 public:
-  explicit PrintValueVisitor(std::ostream &out) : out_(out) {}
+  explicit PrintValueVisitor(const SymbolTable &table, std::ostream &out)
+      : table_(table), out_(out) {}
   void operator()(const IntValue &value);
   void operator()(const VarValue &value);
   void operator()(const GlobValue &value);
 };
 
 class PrintExpVisitor {
+  const SymbolTable &table_;
   std::ostream &out_;
 
 public:
-  explicit PrintExpVisitor(std::reference_wrapper<std::ostream> out)
-      : out_(out) {}
+  explicit PrintExpVisitor(const SymbolTable &table,
+                           std::reference_wrapper<std::ostream> out)
+      : table_(table), out_(out) {}
   void operator()(const HaltExp &exp);
   void operator()(const FunExp &exp);
   void operator()(const JoinExp &exp);

--- a/src/anf.cpp
+++ b/src/anf.cpp
@@ -8,20 +8,26 @@ namespace lambcalc {
 namespace anf {
 
 static int counter = 0;
-std::string fresh() { return std::string("tmp") + std::to_string(counter++); }
+Symbol fresh(SymbolTable &table) {
+  return table.lookup(std::string("tmp") + std::to_string(counter++));
+}
 void resetCounter() { counter = 0; }
 
 template <StringLiteral lit> struct StringValueVisitor {
-  std::string operator()(VarValue v) { return v.var; }
-  std::string operator()(GlobValue v) { return v.glob; }
-  std::string operator()(auto) {
+  Symbol operator()(VarValue v) { return v.var; }
+  Symbol operator()(GlobValue v) { return v.glob; }
+  Symbol operator()(auto) {
     throw std::runtime_error(std::string(lit.value) +
                              " expected to return var or glob");
   }
 };
 
-struct AnfConvertVisitor {
+class AnfConvertVisitor {
+  SymbolTable &table_;
   Cont k;
+
+public:
+  AnfConvertVisitor(SymbolTable &table, Cont k) : table_(table), k(k) {}
   std::unique_ptr<Exp> operator()(ast::IntExp &exp) {
     return k(IntValue{exp.value});
   }
@@ -29,8 +35,8 @@ struct AnfConvertVisitor {
     return k(VarValue{exp.name});
   }
   std::unique_ptr<Exp> operator()(ast::LamExp<std::unique_ptr> &exp) {
-    auto body = convert(*exp.body);
-    auto name = fresh();
+    auto body = convert(table_, *exp.body);
+    auto name = fresh(table_);
     return make(FunExp{
         .name = name,
         .params = {exp.param},
@@ -39,59 +45,68 @@ struct AnfConvertVisitor {
     });
   }
   std::unique_ptr<Exp> operator()(ast::AppExp<std::unique_ptr> &exp) {
-    return ast::convert(*exp.fn, [&arg = *exp.arg, &k = k](Value fnValue) {
-      std::string fnName =
-          std::visit(StringValueVisitor<"function">{}, std::move(fnValue));
-      return ast::convert(arg,
-                          [fnName = std::move(fnName), &k = k](Value argValue) {
-                            auto name = fresh();
-                            return make(AppExp{
-                                .name = name,
-                                .funName = fnName,
-                                .paramValues = {argValue},
-                                .rest = k(VarValue{name}),
-                            });
-                          });
-    });
-  }
-  std::unique_ptr<Exp> operator()(ast::BopExp<std::unique_ptr> &exp) {
     return ast::convert(
-        *exp.arg1, [bop = exp.bop, &arg2 = *exp.arg2, &k = k](Value arg1Value) {
-          return ast::convert(arg2, [bop, arg1Value = std::move(arg1Value),
-                                     &k = k](Value arg2Value) {
-            auto name = fresh();
-            return make(BopExp{
-                .name = name,
-                .bop = bop,
-                .param1 = arg1Value,
-                .param2 = arg2Value,
-                .rest = k(VarValue{name}),
-            });
-          });
+        table_, *exp.fn,
+        [&table = table_, &arg = *exp.arg, &k = k](Value fnValue) {
+          Symbol fnName =
+              std::visit(StringValueVisitor<"function">{}, std::move(fnValue));
+          return ast::convert(
+              table, arg,
+              [&table, fnName = std::move(fnName), &k = k](Value argValue) {
+                auto name = fresh(table);
+                return make(AppExp{
+                    .name = name,
+                    .funName = fnName,
+                    .paramValues = {argValue},
+                    .rest = k(VarValue{name}),
+                });
+              });
         });
   }
+  std::unique_ptr<Exp> operator()(ast::BopExp<std::unique_ptr> &exp) {
+    return ast::convert(table_, *exp.arg1,
+                        [&table = table_, bop = exp.bop, &arg2 = *exp.arg2,
+                         &k = k](Value arg1Value) {
+                          return ast::convert(table, arg2,
+                                              [&table, bop,
+                                               arg1Value = std::move(arg1Value),
+                                               &k = k](Value arg2Value) {
+                                                auto name = fresh(table);
+                                                return make(BopExp{
+                                                    .name = name,
+                                                    .bop = bop,
+                                                    .param1 = arg1Value,
+                                                    .param2 = arg2Value,
+                                                    .rest = k(VarValue{name}),
+                                                });
+                                              });
+                        });
+  }
   std::unique_ptr<Exp> operator()(ast::IfExp<std::unique_ptr> &exp) {
-    return ast::convert(*exp.cond, [&thenBranch = *exp.then,
-                                    &elseBranch = *exp.els,
-                                    &k = k](Value condValue) {
-      auto joinName = fresh();
-      auto slot = fresh();
-      return make(JoinExp{
-          .name = joinName,
-          .slot = std::optional{slot},
-          .body = k(VarValue{slot}),
-          .rest = make(IfExp{
-              .cond = condValue,
-              .thenBranch = ast::convert(
-                  thenBranch,
-                  [&joinName](Value value) {
-                    return make(
-                        JumpExp{joinName, std::optional{std::move(value)}});
-                  }),
-              .elseBranch = ast::convert(elseBranch, [&joinName](Value value) {
-                return make(JumpExp{joinName, std::optional{std::move(value)}});
-              })})});
-    });
+    return ast::convert(
+        table_, *exp.cond,
+        [&table = table_, &thenBranch = *exp.then, &elseBranch = *exp.els,
+         &k = k](Value condValue) {
+          auto joinName = fresh(table);
+          auto slot = fresh(table);
+          return make(JoinExp{
+              .name = joinName,
+              .slot = std::optional{slot},
+              .body = k(VarValue{slot}),
+              .rest = make(IfExp{
+                  .cond = condValue,
+                  .thenBranch = ast::convert(
+                      table, thenBranch,
+                      [&joinName](Value value) {
+                        return make(
+                            JumpExp{joinName, std::optional{std::move(value)}});
+                      }),
+                  .elseBranch =
+                      ast::convert(table, elseBranch, [&joinName](Value value) {
+                        return make(
+                            JumpExp{joinName, std::optional{std::move(value)}});
+                      })})});
+        });
   }
 };
 
@@ -99,8 +114,9 @@ std::unique_ptr<Exp> make(Exp &&exp) {
   return std::make_unique<Exp>(std::move(exp));
 }
 
-std::unique_ptr<Exp> convert(ast::Exp<> &exp) {
-  return ast::convert(exp, [](Value value) { return make(HaltExp{value}); });
+std::unique_ptr<Exp> convert(SymbolTable &table, ast::Exp<> &exp) {
+  return ast::convert(table, exp,
+                      [](Value value) { return make(HaltExp{value}); });
 }
 
 struct DestructorVisitor
@@ -126,21 +142,21 @@ template <template <class> class Ptr> using K = std::vector<KFrame<Ptr>>;
 template <template <class> class Ptr> using K2 = std::vector<K2Frame<Ptr>>;
 template <template <class> class Ptr> struct K2_Lam1 {
   K<Ptr> k;
-  std::string v;
+  Symbol v;
 };
 
 struct K2_Lam2 {
-  std::string f, v;
+  Symbol f, v;
   std::unique_ptr<Exp> body;
 };
 
 struct K2_App1 {
-  std::string r, f;
+  Symbol r, f;
   Value x;
 };
 
 struct K2_Bop1 {
-  std::string r;
+  Symbol r;
   ast::Bop bop;
   Value x, y;
 };
@@ -148,20 +164,20 @@ struct K2_Bop1 {
 template <template <class> class Ptr> struct K2_If1 {
   ast::Exp<Ptr> &t;
   ast::Exp<Ptr> &f;
-  std::string j, p;
+  Symbol j, p;
   Value c;
 };
 
 template <template <class> class Ptr> struct K2_If2 {
   ast::Exp<Ptr> &f;
-  std::string j, p;
+  Symbol j, p;
   Value c;
   std::unique_ptr<Exp> rest;
 };
 
 struct K2_If3 {
   std::unique_ptr<Exp> t;
-  std::string j, p;
+  Symbol j, p;
   Value c;
   std::unique_ptr<Exp> rest;
 };
@@ -197,7 +213,7 @@ template <template <class> class Ptr> struct K_If1 {
 };
 
 struct K_If2 {
-  std::string j;
+  Symbol j;
 };
 
 template <template <class> class Ptr>
@@ -208,7 +224,7 @@ struct KFrame : public std::variant<K_App1<Ptr>, K_App2, K_Bop1<Ptr>, K_Bop2,
 };
 
 template <template <class> class Ptr>
-std::unique_ptr<Exp> convertDefunc(ast::Exp<Ptr> &root) {
+std::unique_ptr<Exp> convertDefunc(SymbolTable &table, ast::Exp<Ptr> &root) {
   // Parameters for apply_k2, apply_k, and go normalized.
   // If two parameters for different functions have the same type,
   // they can share the same variable because tail calls destroy the stack.
@@ -231,7 +247,7 @@ std::unique_ptr<Exp> convertDefunc(ast::Exp<Ptr> &root) {
       std::visit(
           overloaded{
               [&](K2_Lam1<Ptr> &frame) {
-                auto f = fresh();
+                auto f = fresh(table);
                 k = std::move(frame.k);
                 value = VarValue{f};
                 k2.emplace_back(std::in_place_type<K2_Lam2>, f, frame.v,
@@ -305,7 +321,7 @@ std::unique_ptr<Exp> convertDefunc(ast::Exp<Ptr> &root) {
               },
               [&](K_App2 &frame) {
                 std::visit(overloaded{[&](VarValue &f) {
-                                        auto r = fresh();
+                                        auto r = fresh(table);
                                         k2.emplace_back(
                                             std::in_place_type<K2_App1>, r,
                                             f.var, std::move(value));
@@ -324,14 +340,14 @@ std::unique_ptr<Exp> convertDefunc(ast::Exp<Ptr> &root) {
                 dispatch = GO;
               },
               [&](K_Bop2 &frame) {
-                auto r = fresh();
+                auto r = fresh(table);
                 k2.emplace_back(std::in_place_type<K2_Bop1>, r, frame.bop,
                                 std::move(frame.x), std::move(value));
                 value = VarValue{r};
               },
               [&](K_If1<Ptr> &frame) {
-                auto j = fresh();
-                auto p = fresh();
+                auto j = fresh(table);
+                auto p = fresh(table);
 
                 k2.emplace_back(std::in_place_type<K2_If1<Ptr>>, frame.t,
                                 frame.f, std::move(j), p, std::move(value));
@@ -386,12 +402,14 @@ std::unique_ptr<Exp> convertDefunc(ast::Exp<Ptr> &root) {
   return nullptr;
 }
 
-template std::unique_ptr<Exp> convertDefunc(ast::Exp<std::unique_ptr> &root);
-template std::unique_ptr<Exp> convertDefunc(ast::Exp<raw_ptr> &root);
+template std::unique_ptr<Exp> convertDefunc(SymbolTable &table,
+                                            ast::Exp<std::unique_ptr> &root);
+template std::unique_ptr<Exp> convertDefunc(SymbolTable &table,
+                                            ast::Exp<raw_ptr> &root);
 
-std::string Exp::dump() {
+std::string Exp::dump(const SymbolTable &table) {
   std::ostringstream out;
-  out << *this;
+  print(table, out, *this);
   return out.str();
 }
 
@@ -399,8 +417,8 @@ std::string Exp::dump() {
 
 namespace ast {
 
-std::unique_ptr<anf::Exp> convert(Exp<> &exp, anf::Cont k) {
-  return std::visit(anf::AnfConvertVisitor{.k = std::move(k)}, exp);
+std::unique_ptr<anf::Exp> convert(SymbolTable &table, Exp<> &exp, anf::Cont k) {
+  return std::visit(anf::AnfConvertVisitor{table, std::move(k)}, exp);
 }
 
 } // namespace ast

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -13,9 +13,10 @@ std::unique_ptr<Exp<>> make(Exp<> &&exp) {
   return std::make_unique<Exp<>>(std::move(exp));
 }
 
-template <template <class> class Ptr> std::string Exp<Ptr>::dump() {
+template <template <class> class Ptr>
+std::string Exp<Ptr>::dump(const SymbolTable &table) {
   std::ostringstream out;
-  out << *this;
+  print(table, out, *this);
   return out.str();
 }
 

--- a/src/convert.cpp
+++ b/src/convert.cpp
@@ -2,6 +2,7 @@
 #include "utils.h"
 #include "visitor.h"
 #include <cassert>
+#include <functional>
 #include <stack>
 
 namespace lambcalc {
@@ -10,11 +11,12 @@ using namespace anf;
 
 using FreeVarsPipeline = WorklistVisitor<ExpValueVisitor<DefaultVisitor>,
                                          WorklistTask<Exp>, std::stack>;
-class FreeVarsVisitor : public FreeVarsPipeline {
-  std::set<Var> &freeVars_;
+template <typename Comparator> class FreeVarsVisitor : public FreeVarsPipeline {
+  std::set<Var, Comparator> &freeVars_;
 
 public:
-  explicit FreeVarsVisitor(std::set<Var> &freeVars) : freeVars_(freeVars) {}
+  explicit FreeVarsVisitor(std::set<Var, Comparator> &freeVars)
+      : freeVars_(freeVars) {}
   using FreeVarsPipeline::operator();
   using FreeVarsPipeline::addWorklist;
 
@@ -39,6 +41,25 @@ public:
   }
 };
 
+template <typename Comparator = std::less<Var>>
+std::set<Var, Comparator> freeVars(Comparator cmp, Exp &root) {
+  std::set<Var, Comparator> freeVars(cmp);
+  FreeVarsVisitor visitor(freeVars);
+  auto &worklist = visitor.getWorklist();
+  std::visit(visitor, root);
+  while (!worklist.empty()) {
+    auto task = std::move(worklist.top());
+    worklist.pop();
+    std::visit(overloaded{[&](const NodeTask<Exp> &n) {
+                            Exp &exp = std::get<1>(n);
+                            std::visit(visitor, exp);
+                          },
+                          [](FnTask &f) { std::move(f)(); }},
+               task);
+  }
+  return freeVars;
+}
+
 using ClosureConvertPipeline =
     WorklistVisitor<DefaultVisitor, WorklistTask<Exp>, std::stack>;
 class ClosureConvertVisitor : public ClosureConvertPipeline {
@@ -57,7 +78,10 @@ public:
   void operator()(FunExp &exp) {
     assert(parentLink_ != nullptr &&
            "Expected FunExp to have a unique_ptr link");
-    auto freeVariables = freeVars(**parentLink_);
+    auto cmp = [&table = table_](Var a, Var b) {
+      return table.lookup(a) < table.lookup(b);
+    };
+    auto freeVariables = freeVars(cmp, **parentLink_);
     auto closureParam = fresh("closure");
     exp.params.insert(exp.params.begin(), closureParam);
     auto body = std::move(exp.body);
@@ -96,23 +120,7 @@ public:
   }
 };
 
-std::set<Var> freeVars(Exp &root) {
-  std::set<Var> freeVars;
-  FreeVarsVisitor visitor(freeVars);
-  auto &worklist = visitor.getWorklist();
-  std::visit(visitor, root);
-  while (!worklist.empty()) {
-    auto task = std::move(worklist.top());
-    worklist.pop();
-    std::visit(overloaded{[&](const NodeTask<Exp> &n) {
-                            Exp &exp = std::get<1>(n);
-                            std::visit(visitor, exp);
-                          },
-                          [](FnTask &f) { std::move(f)(); }},
-               task);
-  }
-  return freeVars;
-}
+std::set<Var> freeVars(Exp &root) { return freeVars(std::less<Var>(), root); }
 
 std::unique_ptr<Exp> closureConvert(SymbolTable &table,
                                     std::unique_ptr<Exp> &&start) {

--- a/src/convert.cpp
+++ b/src/convert.cpp
@@ -43,14 +43,16 @@ using ClosureConvertPipeline =
     WorklistVisitor<DefaultVisitor, WorklistTask<Exp>, std::stack>;
 class ClosureConvertVisitor : public ClosureConvertPipeline {
   int counter_;
+  SymbolTable &table_;
   std::unique_ptr<Exp> *parentLink_;
   Var fresh(std::string_view prefix) {
-    return prefix.data() + std::to_string(counter_++);
+    return table_.lookup(prefix.data() + std::to_string(counter_++));
   }
 
 public:
   using ClosureConvertPipeline::operator();
-  ClosureConvertVisitor() : counter_(0), parentLink_(nullptr) {}
+  ClosureConvertVisitor(SymbolTable &table)
+      : counter_(0), table_(table), parentLink_(nullptr) {}
   void setParent(std::unique_ptr<Exp> *parentLink) { parentLink_ = parentLink; }
   void operator()(FunExp &exp) {
     assert(parentLink_ != nullptr &&
@@ -112,8 +114,9 @@ std::set<Var> freeVars(Exp &root) {
   return freeVars;
 }
 
-std::unique_ptr<Exp> closureConvert(std::unique_ptr<Exp> &&start) {
-  ClosureConvertVisitor visitor;
+std::unique_ptr<Exp> closureConvert(SymbolTable &table,
+                                    std::unique_ptr<Exp> &&start) {
+  ClosureConvertVisitor visitor(table);
   auto &worklist = visitor.getWorklist();
   auto root = std::move(start);
   worklist.emplace(&root);

--- a/src/hoist.cpp
+++ b/src/hoist.cpp
@@ -10,17 +10,19 @@ using HoistPipeline =
     WorklistVisitor<DefaultVisitor, WorklistTask<Exp>, std::stack>;
 class HoistVisitor : public HoistPipeline {
   int counter_;
+  SymbolTable &table_;
   std::vector<Join> currentJoins_;
   std::vector<Function> collected_;
   std::unique_ptr<Exp> *parentLink_;
 
   Var fresh(std::string_view prefix) {
-    return prefix.data() + std::to_string(counter_++);
+    return table_.lookup(prefix.data() + std::to_string(counter_++));
   }
 
 public:
   using HoistPipeline::operator();
-  HoistVisitor() : counter_(0), parentLink_(nullptr) {}
+  HoistVisitor(SymbolTable &table)
+      : counter_(0), table_(table), parentLink_(nullptr) {}
   void setParentLink(std::unique_ptr<Exp> *parentLink) {
     parentLink_ = parentLink;
   }
@@ -80,10 +82,11 @@ public:
   }
 };
 
-std::vector<Function> hoist(std::unique_ptr<anf::Exp> &&start) {
-  HoistVisitor visitor;
-  auto root =
-      make(FunExp{"main", {}, std::move(start), make(HaltExp{IntValue{0}})});
+std::vector<Function> hoist(SymbolTable &table,
+                            std::unique_ptr<anf::Exp> &&start) {
+  HoistVisitor visitor(table);
+  auto root = make(FunExp{
+      table.lookup("main"), {}, std::move(start), make(HaltExp{IntValue{0}})});
   auto &worklist = visitor.getWorklist();
   worklist.emplace(&root);
   while (!worklist.empty()) {

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -13,25 +13,26 @@ Token Lexer::getToken() {
     return Token::Arrow;
   }
   if (isalpha(lastChar_)) {
-    identifier_.assign(1, lastChar_);
-    while (isalnum((lastChar_ = in_.get()))) {
+    std::string identifier;
+    do {
       identifier_ += lastChar_;
-    }
-    if (identifier_ == "fn") {
+    } while (isalnum((lastChar_ = in_.get())));
+    if (identifier == "fn") {
       return Token::Fn;
     }
-    if (identifier_ == "=>") {
+    if (identifier == "=>") {
       return Token::Arrow;
     }
-    if (identifier_ == "if") {
+    if (identifier == "if") {
       return Token::If;
     }
-    if (identifier_ == "then") {
+    if (identifier == "then") {
       return Token::Then;
     }
-    if (identifier_ == "else") {
+    if (identifier == "else") {
       return Token::Else;
     }
+    identifier_ = table_.lookup(identifier);
     return Token::Identifier;
   }
   if (isdigit(lastChar_)) {

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -13,10 +13,11 @@ Token Lexer::getToken() {
     return Token::Arrow;
   }
   if (isalpha(lastChar_)) {
-    std::string identifier;
-    do {
-      identifier_ += lastChar_;
-    } while (isalnum((lastChar_ = in_.get())));
+    std::string identifier(1, lastChar_);
+    while (isalnum((lastChar_ = in_.get()))) {
+      identifier += lastChar_;
+    }
+    identifier_ = table_.lookup(identifier);
     if (identifier == "fn") {
       return Token::Fn;
     }
@@ -32,7 +33,6 @@ Token Lexer::getToken() {
     if (identifier == "else") {
       return Token::Else;
     }
-    identifier_ = table_.lookup(identifier);
     return Token::Identifier;
   }
   if (isdigit(lastChar_)) {

--- a/src/lower.cpp
+++ b/src/lower.cpp
@@ -157,8 +157,8 @@ public:
     auto tuplePtr = builder_.CreateIntToPtr(tupleInt, builder_.getPtrTy());
     auto gep = builder_.CreateGEP(builder_.getInt64Ty(), tuplePtr,
                                   {builder_.getInt64(exp.index)});
-    namedValues_[exp.name] =
-        builder_.CreateLoad(builder_.getInt64Ty(), gep, exp.name);
+    namedValues_[exp.name] = builder_.CreateLoad(builder_.getInt64Ty(), gep,
+                                                 table_.lookup(exp.name));
     return LLVMLowerPipeline::operator()(exp);
   }
   void operator()(IfExp &exp) { return LLVMLowerPipeline::operator()(exp); }
@@ -278,8 +278,8 @@ void lowerModule(const SymbolTable &table, std::vector<Function> &&fns,
       builder->SetInsertPoint(loweredBlock);
       if (block.slot) {
         auto slot = spillSlots[block.name];
-        namedValues[*block.slot] =
-            builder->CreateLoad(builder->getInt64Ty(), slot, *block.slot);
+        namedValues[*block.slot] = builder->CreateLoad(
+            builder->getInt64Ty(), slot, table.lookup(*block.slot));
       }
       lowerBlock(visitor, block);
     }

--- a/src/lower.cpp
+++ b/src/lower.cpp
@@ -34,21 +34,23 @@ using LLVMLowerPipeline =
     MatchIfJump<WorklistVisitor<ExpValueVisitor<DefaultVisitor>,
                                 WorklistTask<Exp>, std::stack>>;
 class LLVMLowerVisitor : public LLVMLowerPipeline {
+  const SymbolTable &table_;
   LLVMContext &ctx_;
   Module &module_;
   IRBuilder<> &builder_;
   llvm::Value *value_;
-  llvm::StringMap<llvm::AllocaInst *> &spillSlots_;
-  llvm::StringMap<llvm::Value *> &namedValues_;
-  llvm::StringMap<llvm::BasicBlock *> &namedBlocks_;
+  llvm::DenseMap<Symbol, llvm::AllocaInst *> &spillSlots_;
+  llvm::DenseMap<Symbol, llvm::Value *> &namedValues_;
+  llvm::DenseMap<Symbol, llvm::BasicBlock *> &namedBlocks_;
 
 public:
-  LLVMLowerVisitor(LLVMContext &ctx, Module &module, IRBuilder<> &builder,
-                   llvm::StringMap<llvm::AllocaInst *> &spillSlots,
-                   llvm::StringMap<llvm::Value *> &namedValues,
-                   llvm::StringMap<llvm::BasicBlock *> &namedBlocks)
-      : ctx_(ctx), module_(module), builder_(builder), value_(nullptr),
-        spillSlots_(spillSlots), namedValues_(namedValues),
+  LLVMLowerVisitor(const SymbolTable &table, LLVMContext &ctx, Module &module,
+                   IRBuilder<> &builder,
+                   llvm::DenseMap<Symbol, llvm::AllocaInst *> &spillSlots,
+                   llvm::DenseMap<Symbol, llvm::Value *> &namedValues,
+                   llvm::DenseMap<Symbol, llvm::BasicBlock *> &namedBlocks)
+      : table_(table), ctx_(ctx), module_(module), builder_(builder),
+        value_(nullptr), spillSlots_(spillSlots), namedValues_(namedValues),
         namedBlocks_(namedBlocks) {}
   void visitIntValue(IntValue &value) override {
     value_ = builder_.getInt64(value.value);
@@ -59,12 +61,14 @@ public:
   void visitGlobValue(GlobValue &value) override {
     llvm::Function *function;
     llvm::GlobalVariable *global;
-    if ((function = module_.getFunction(value.glob))) {
+    if ((function = module_.getFunction(table_.lookup(value.glob)))) {
       value_ = builder_.CreatePtrToInt(function, builder_.getInt64Ty());
-    } else if ((global = module_.getGlobalVariable(value.glob))) {
+    } else if ((global =
+                    module_.getGlobalVariable(table_.lookup(value.glob)))) {
       value_ = builder_.CreatePtrToInt(global, builder_.getInt64Ty());
     } else {
-      value_ = module_.getOrInsertGlobal(value.glob, builder_.getInt64Ty());
+      value_ = module_.getOrInsertGlobal(table_.lookup(value.glob),
+                                         builder_.getInt64Ty());
     }
   }
 
@@ -98,10 +102,12 @@ public:
       auto fPtrTy = PointerType::get(fty, 0);
       auto fnPtrInt = namedValues_[exp.funName];
       auto fn = builder_.CreateIntToPtr(fnPtrInt, fPtrTy);
-      namedValues_[exp.name] = builder_.CreateCall(fty, fn, params, exp.name);
+      namedValues_[exp.name] =
+          builder_.CreateCall(fty, fn, params, table_.lookup(exp.name));
     } else {
-      auto fn = module_.getFunction(exp.funName);
-      namedValues_[exp.name] = builder_.CreateCall(fn, params, exp.name);
+      auto fn = module_.getFunction(table_.lookup(exp.funName));
+      namedValues_[exp.name] =
+          builder_.CreateCall(fn, params, table_.lookup(exp.name));
     }
     return LLVMLowerPipeline::operator()(exp);
   }
@@ -123,15 +129,16 @@ public:
       break;
     }
     namedValues_[exp.name] =
-        builder_.CreateBinOp(bop, param1, param2, exp.name);
+        builder_.CreateBinOp(bop, param1, param2, table_.lookup(exp.name));
     return LLVMLowerPipeline::operator()(exp);
   }
   void operator()(TupleExp &exp) {
     auto mallocTy =
         FunctionType::get(builder_.getPtrTy(), builder_.getInt64Ty(), false);
     auto malloc = module_.getOrInsertFunction("malloc", mallocTy);
-    auto ptr = builder_.CreateCall(
-        malloc, {builder_.getInt64(exp.values.size() * 8)}, exp.name);
+    auto ptr =
+        builder_.CreateCall(malloc, {builder_.getInt64(exp.values.size() * 8)},
+                            table_.lookup(exp.name));
     namedValues_[exp.name] =
         builder_.CreatePtrToInt(ptr, builder_.getInt64Ty());
     for (size_t i = 0; i < exp.values.size(); ++i) {
@@ -227,29 +234,31 @@ std::unique_ptr<Module> initializeModuleAndManagers(const DataLayout &layout) {
   return mod;
 }
 
-void lowerModule(std::vector<Function> &&fns, Module &module) {
+void lowerModule(const SymbolTable &table, std::vector<Function> &&fns,
+                 Module &module) {
   auto builder = std::make_unique<IRBuilder<>>(*ctx);
   for (auto &fn : fns) {
     // getPtrTy() gets an opaque pointer, which is preferred for modern LLVM
     // than a typed pointer.
     auto ty = getFunctionType(*builder, fn.params);
-    llvm::Function::Create(ty, llvm::GlobalValue::ExternalLinkage, fn.name,
-                           module);
+    llvm::Function::Create(ty, llvm::GlobalValue::ExternalLinkage,
+                           table.lookup(fn.name), module);
   }
   for (auto &fn : fns) {
-    StringMap<llvm::AllocaInst *> spillSlots;
-    StringMap<llvm::Value *> namedValues;
-    StringMap<llvm::BasicBlock *> namedBlocks;
-    LLVMLowerVisitor visitor(*ctx, module, *builder, spillSlots, namedValues,
-                             namedBlocks);
+    DenseMap<Symbol, llvm::AllocaInst *> spillSlots;
+    DenseMap<Symbol, llvm::Value *> namedValues;
+    DenseMap<Symbol, llvm::BasicBlock *> namedBlocks;
+    LLVMLowerVisitor visitor(table, *ctx, module, *builder, spillSlots,
+                             namedValues, namedBlocks);
 
-    auto loweredFn = module.getFunction(fn.name);
+    auto loweredFn = module.getFunction(table.lookup(fn.name));
     auto loweredEntryBlock =
-        BasicBlock::Create(*ctx, fn.entryBlock.name, loweredFn);
+        BasicBlock::Create(*ctx, table.lookup(fn.entryBlock.name), loweredFn);
     namedBlocks[fn.entryBlock.name] = loweredEntryBlock;
     builder->SetInsertPoint(loweredEntryBlock);
     for (auto &block : fn.blocks) {
-      auto loweredBlock = BasicBlock::Create(*ctx, block.name, loweredFn);
+      auto loweredBlock =
+          BasicBlock::Create(*ctx, table.lookup(block.name), loweredFn);
       namedBlocks[block.name] = loweredBlock;
       // preprocess spill slots
       if (block.slot) {
@@ -258,8 +267,8 @@ void lowerModule(std::vector<Function> &&fns, Module &module) {
     }
     size_t i = 0;
     for (auto &arg : loweredFn->args()) {
-      const std::string &param = fn.params[i++];
-      arg.setName(param);
+      const Symbol &param = fn.params[i++];
+      arg.setName(table.lookup(param));
       namedValues[param] = &arg;
     }
 
@@ -278,16 +287,18 @@ void lowerModule(std::vector<Function> &&fns, Module &module) {
   }
 }
 
-std::unique_ptr<Module> lower(std::vector<Function> &&fns) {
+std::unique_ptr<Module> lower(const SymbolTable &table,
+                              std::vector<Function> &&fns) {
   auto module = initializeModuleAndManagers();
-  lowerModule(std::move(fns), *module);
+  lowerModule(table, std::move(fns), *module);
   return module;
 }
 
-std::unique_ptr<Module> lower(std::vector<Function> &&fns,
+std::unique_ptr<Module> lower(const SymbolTable &table,
+                              std::vector<Function> &&fns,
                               const DataLayout &layout) {
   auto module = initializeModuleAndManagers(layout);
-  lowerModule(std::move(fns), *module);
+  lowerModule(table, std::move(fns), *module);
   return module;
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,6 +7,7 @@
 #include "lower.h"
 #include "parser.h"
 #include "rename.h"
+#include "symbol.h"
 #include "utils.h"
 #include "llvm/Support/TargetSelect.h"
 #include <iostream>
@@ -24,6 +25,7 @@ const std::unordered_map<ast::Bop, std::optional<std::pair<int, int>>>
                    {ast::Bop::Times, {{3, 4}}}};
 
 int main() {
+  SymbolTable table;
   arena::LinkedAllocator allocator(1 << 28);
   arena::Typed<ast::Exp<raw_ptr>, decltype(allocator)> expAlloc(allocator);
 
@@ -33,7 +35,7 @@ int main() {
 
   std::unique_ptr<llvm::orc::KaleidoscopeJIT> jit =
       ExitOnErr(llvm::orc::KaleidoscopeJIT::Create());
-  Lexer lexer(std::cin);
+  Lexer lexer(table, std::cin);
   Parser<raw_ptr, decltype(expAlloc)> parser(expAlloc, lexer, defaultInfixBp);
   while (true) {
     allocator.reset();
@@ -52,7 +54,7 @@ int main() {
       }
       exp = parser.parseExpression();
     } catch (ParserException &e) {
-      std::cerr << e.what() << std::endl;
+      std::cerr << e.what() << "\n";
       if (e.abort()) {
         break;
       } else {
@@ -60,24 +62,24 @@ int main() {
       }
     }
     if constexpr (LAMBCALC_DEBUG) {
-      std::cout << *exp << std::endl;
+      std::cout << exp->dump(table) << "\n";
     }
     try {
-      ast::rename(*exp);
+      ast::rename(table, *exp);
     } catch (ast::NotInScopeException &e) {
-      std::cerr << e.what() << std::endl;
+      std::cerr << e.what() << "\n";
       continue;
     }
     if constexpr (LAMBCALC_DEBUG) {
-      std::cout << "After renaming: " << *exp << std::endl;
+      std::cout << "After renaming: " << exp->dump(table) << "\n";
     }
-    auto anf = anf::convertDefunc(*exp);
-    auto convert = convert::closureConvert(std::move(anf));
+    auto anf = anf::convertDefunc(table, *exp);
+    auto convert = convert::closureConvert(table, std::move(anf));
     if constexpr (LAMBCALC_DEBUG) {
-      std::cout << *convert << std::endl;
+      std::cout << convert->dump(table) << "\n";
     }
 
-    auto hoisted = anf::hoist(std::move(convert));
+    auto hoisted = anf::hoist(table, std::move(convert));
     if constexpr (LAMBCALC_DEBUG) {
       for (const auto &fn : hoisted) {
         std::cout << fn.name << "( ";
@@ -89,19 +91,19 @@ int main() {
         if (fn.entryBlock.slot) {
           std::cout << *fn.entryBlock.slot;
         }
-        std::cout << " >: " << std::endl << *fn.entryBlock.body << std::endl;
+        std::cout << " >: " << "\n" << fn.entryBlock.body->dump(table) << "\n";
         for (const auto &block : fn.blocks) {
           std::cout << block.name << " < ";
           if (block.slot) {
             std::cout << *block.slot;
           }
-          std::cout << " >: " << std::endl << *block.body << std::endl;
+          std::cout << " >: " << "\n" << block.body->dump(table) << "\n";
         }
 
         std::cout << std::endl;
       }
     }
-    auto mod = lower::lower(std::move(hoisted), jit->getDataLayout());
+    auto mod = lower::lower(table, std::move(hoisted), jit->getDataLayout());
     if constexpr (LAMBCALC_DEBUG) {
       mod->dump();
     }

--- a/src/rename.cpp
+++ b/src/rename.cpp
@@ -13,19 +13,20 @@ using AlphaRenamePipeline =
 template <template <class> class Ptr>
 class AlphaRenameVisitor : public AlphaRenamePipeline<Ptr> {
   int counter_;
-  std::unordered_map<std::string, std::string> rename_;
+  SymbolTable &table_;
+  std::unordered_map<Symbol, Symbol> rename_;
 
-  std::string fresh(std::string_view name) {
-    return name.data() + std::to_string(counter_++);
+  Symbol fresh(std::string_view name) {
+    return table_.lookup(name.data() + std::to_string(counter_++));
   }
 
 public:
-  AlphaRenameVisitor() : counter_(0) {}
+  AlphaRenameVisitor(SymbolTable &table) : counter_(0), table_(table) {}
   using AlphaRenamePipeline<Ptr>::operator();
   using AlphaRenamePipeline<Ptr>::getWorklist;
   void operator()(LamExp<Ptr> &exp) {
-    auto renamed = fresh(exp.param);
-    std::optional<std::string> oldRenameParam =
+    auto renamed = fresh(table_.lookup(exp.param));
+    std::optional<Symbol> oldRenameParam =
         rename_.contains(exp.param) ? std::optional{rename_[exp.param]}
                                     : std::nullopt;
     rename_[exp.param] = renamed;
@@ -46,13 +47,14 @@ public:
     if (rename_.contains(exp.name)) {
       exp.name = rename_[exp.name];
     } else {
-      throw NotInScopeException(exp.name);
+      throw NotInScopeException(table_.lookup(exp.name));
     }
   }
 };
 
-template <template <class> class Ptr> void rename(ast::Exp<Ptr> &exp) {
-  AlphaRenameVisitor<Ptr> visitor;
+template <template <class> class Ptr>
+void rename(SymbolTable &table, ast::Exp<Ptr> &exp) {
+  AlphaRenameVisitor<Ptr> visitor(table);
   auto &worklist = visitor.getWorklist();
   std::visit(visitor, exp);
   while (!worklist.empty()) {
@@ -67,8 +69,8 @@ template <template <class> class Ptr> void rename(ast::Exp<Ptr> &exp) {
   }
 }
 
-template void rename(ast::Exp<std::unique_ptr> &);
-template void rename(ast::Exp<raw_ptr> &);
+template void rename(SymbolTable &, ast::Exp<std::unique_ptr> &);
+template void rename(SymbolTable &, ast::Exp<raw_ptr> &);
 
 } // namespace ast
 } // namespace lambcalc

--- a/src/visitor.cpp
+++ b/src/visitor.cpp
@@ -17,33 +17,15 @@ std::string binOpString(ast::Bop bop) {
   std::unreachable();
 }
 
-template <typename T>
-void print_vector(std::ostream &os, const std::vector<T> &vec) {
-  os << "[";
-  for (auto it = vec.begin(); it != vec.end(); ++it) {
-    os << *it;
-    if (it + 1 != vec.end()) {
-      os << ", ";
-    }
-  }
-  os << "]";
-}
-
-template <typename T>
-void print_optional(std::ostream &os, std::optional<T> opt) {
-  if (opt) {
-    os << "<" << *opt << ">";
-  } else {
-    os << "<>";
-  }
+void print(const SymbolTable &table, std::ostream &os, Symbol sym) {
+  os << table.lookup(sym);
 }
 
 namespace ast {
 
 template <template <class> class Ptr>
-std::ostream &operator<<(std::ostream &os, const Exp<Ptr> &exp) {
-  std::visit(PrintExpVisitor<Ptr>(os), exp);
-  return os;
+void print(const SymbolTable &table, std::ostream &os, const Exp<Ptr> &exp) {
+  std::visit(PrintExpVisitor<Ptr>(table, os), exp);
 }
 
 template <template <class> class Ptr>
@@ -52,25 +34,39 @@ void PrintExpVisitor<Ptr>::operator()(const IntExp &exp) {
 }
 template <template <class> class Ptr>
 void PrintExpVisitor<Ptr>::operator()(const VarExp &exp) {
-  out_ << exp.name;
+  out_ << table_.lookup(exp.name);
 }
 template <template <class> class Ptr>
 void PrintExpVisitor<Ptr>::operator()(const LamExp<Ptr> &exp) {
-  out_ << "(fn " << exp.param << " => " << *exp.body << ")";
+  out_ << "(fn " << table_.lookup(exp.param) << " => ";
+  print(table_, out_, *exp.body);
+  out_ << ")";
 }
 template <template <class> class Ptr>
 void PrintExpVisitor<Ptr>::operator()(const AppExp<Ptr> &exp) {
-  out_ << "(" << *exp.fn << " " << *exp.arg << ")";
+  out_ << "(";
+  print(table_, out_, *exp.fn);
+  out_ << " ";
+  print(table_, out_, *exp.arg);
+  out_ << ")";
 }
 template <template <class> class Ptr>
 void PrintExpVisitor<Ptr>::operator()(const BopExp<Ptr> &exp) {
-  out_ << "(" << *exp.arg1 << " " << binOpString(exp.bop) << " " << *exp.arg2
-       << ")";
+  out_ << "(";
+  print(table_, out_, *exp.arg1);
+  out_ << " " << binOpString(exp.bop) << " ";
+  print(table_, out_, *exp.arg2);
+  out_ << ")";
 }
 template <template <class> class Ptr>
 void PrintExpVisitor<Ptr>::operator()(const IfExp<Ptr> &exp) {
-  out_ << "(if " << *exp.cond << " then " << *exp.then << " else " << *exp.els
-       << ")";
+  out_ << "(if ";
+  print(table_, out_, *exp.cond);
+  out_ << " then ";
+  print(table_, out_, *exp.then);
+  out_ << " else ";
+  print(table_, out_, *exp.els);
+  out_ << ")";
 }
 
 template class PrintExpVisitor<std::unique_ptr>;
@@ -80,72 +76,123 @@ template class PrintExpVisitor<raw_ptr>;
 
 namespace anf {
 
+template <typename T>
+void print_vector(const SymbolTable &table, std::ostream &os,
+                  const std::vector<T> &vec) {
+  os << "[";
+  for (auto it = vec.begin(); it != vec.end(); ++it) {
+    print(table, os, *it);
+    if (it + 1 != vec.end()) {
+      os << ", ";
+    }
+  }
+  os << "]";
+}
+
+template <typename T>
+void print_optional(const SymbolTable &table, std::ostream &os,
+                    std::optional<T> opt) {
+  if (opt) {
+    os << "<";
+    print(table, os, *opt);
+    os << ">";
+  } else {
+    os << "<>";
+  }
+}
+
 void PrintValueVisitor::operator()(const IntValue &value) {
   out_ << value.value;
 }
-void PrintValueVisitor::operator()(const VarValue &value) { out_ << value.var; }
+void PrintValueVisitor::operator()(const VarValue &value) {
+  out_ << table_.lookup(value.var);
+}
 void PrintValueVisitor::operator()(const GlobValue &value) {
-  out_ << value.glob;
+  out_ << table_.lookup(value.glob);
 }
 
-std::ostream &operator<<(std::ostream &os, const Value &value) {
-  std::visit(PrintValueVisitor(os), value);
-  return os;
+void print(const SymbolTable &table, std::ostream &os, const Value &value) {
+  std::visit(PrintValueVisitor(table, os), value);
+}
+
+void print(const SymbolTable &table, std::ostream &os, const Exp &exp) {
+  std::visit(PrintExpVisitor(table, os), exp);
 }
 
 void PrintExpVisitor::operator()(const HaltExp &exp) {
-  out_ << "HaltExp { " << exp.value << " }";
+  out_ << "HaltExp { ";
+  print(table_, out_, exp.value);
+  out_ << " }";
 }
 
 void PrintExpVisitor::operator()(const FunExp &exp) {
   out_ << "FunExp { " << exp.name << ", ";
-  print_vector(out_, exp.params);
-  out_ << ", " << *exp.body << ", " << *exp.rest << " }";
+  print_vector(table_, out_, exp.params);
+  out_ << ", ";
+  print(table_, out_, *exp.body);
+  out_ << ", ";
+  print(table_, out_, *exp.rest);
+  out_ << " }";
 }
 
 void PrintExpVisitor::operator()(const JoinExp &exp) {
   out_ << "JoinExp { " << exp.name << ", ";
-  print_optional(out_, exp.slot);
-  out_ << ", " << *exp.body << ", " << *exp.rest << " }";
+  print_optional(table_, out_, exp.slot);
+  out_ << ", ";
+  print(table_, out_, *exp.body);
+  out_ << ", ";
+  print(table_, out_, *exp.rest);
+  out_ << " }";
 }
 
 void PrintExpVisitor::operator()(const JumpExp &exp) {
   out_ << "JumpExp { " << exp.joinName << ", ";
-  print_optional(out_, exp.slotValue);
+  print_optional(table_, out_, exp.slotValue);
   out_ << " }";
 }
 
 void PrintExpVisitor::operator()(const AppExp &exp) {
   out_ << "AppExp { " << exp.name << ", " << exp.funName << ", ";
-  print_vector(out_, exp.paramValues);
-  out_ << ", " << *exp.rest << " }";
+  print_vector(table_, out_, exp.paramValues);
+  out_ << ", ";
+  print(table_, out_, *exp.rest);
+  out_ << " }";
 }
 
 void PrintExpVisitor::operator()(const BopExp &exp) {
   std::string bop = binOpString(exp.bop);
-  out_ << "BopExp { " << exp.name << ", " << bop << ", " << exp.param1 << ", "
-       << exp.param2 << ", " << *exp.rest << " }";
+  out_ << "BopExp { " << exp.name << ", " << bop << ", ";
+  print(table_, out_, exp.param1);
+  out_ << ", ";
+  print(table_, out_, exp.param2);
+  out_ << ", ";
+  print(table_, out_, *exp.rest);
+  out_ << " }";
 }
 
 void PrintExpVisitor::operator()(const TupleExp &exp) {
-  out_ << "TupleExp { " << exp.name << ", ";
-  print_vector(out_, exp.values);
-  out_ << ", " << *exp.rest << " }";
+  out_ << "TupleExp { " << table_.lookup(exp.name) << ", ";
+  print_vector(table_, out_, exp.values);
+  out_ << ", ";
+  print(table_, out_, *exp.rest);
+  out_ << " }";
 }
 
 void PrintExpVisitor::operator()(const ProjExp &exp) {
-  out_ << "ProjExp { " << exp.name << ", " << exp.tuple << ", " << exp.index
-       << ", " << *exp.rest << " }";
+  out_ << "ProjExp { " << table_.lookup(exp.name) << ", "
+       << table_.lookup(exp.tuple) << ", " << exp.index << ", ";
+  print(table_, out_, *exp.rest);
+  out_ << " }";
 }
 
 void PrintExpVisitor::operator()(const IfExp &exp) {
-  out_ << "IfExp { " << exp.cond << ", " << *exp.thenBranch << ", "
-       << *exp.elseBranch << " }";
-}
-
-std::ostream &operator<<(std::ostream &os, const Exp &exp) {
-  std::visit(PrintExpVisitor(os), exp);
-  return os;
+  out_ << "IfExp { ";
+  print(table_, out_, exp.cond);
+  out_ << ", ";
+  print(table_, out_, *exp.thenBranch);
+  out_ << ", ";
+  print(table_, out_, *exp.elseBranch);
+  out_ << " }";
 }
 
 } // namespace anf

--- a/src/visitor.cpp
+++ b/src/visitor.cpp
@@ -126,7 +126,7 @@ void PrintExpVisitor::operator()(const HaltExp &exp) {
 }
 
 void PrintExpVisitor::operator()(const FunExp &exp) {
-  out_ << "FunExp { " << exp.name << ", ";
+  out_ << "FunExp { " << table_.lookup(exp.name) << ", ";
   print_vector(table_, out_, exp.params);
   out_ << ", ";
   print(table_, out_, *exp.body);
@@ -136,7 +136,7 @@ void PrintExpVisitor::operator()(const FunExp &exp) {
 }
 
 void PrintExpVisitor::operator()(const JoinExp &exp) {
-  out_ << "JoinExp { " << exp.name << ", ";
+  out_ << "JoinExp { " << table_.lookup(exp.name) << ", ";
   print_optional(table_, out_, exp.slot);
   out_ << ", ";
   print(table_, out_, *exp.body);
@@ -146,13 +146,14 @@ void PrintExpVisitor::operator()(const JoinExp &exp) {
 }
 
 void PrintExpVisitor::operator()(const JumpExp &exp) {
-  out_ << "JumpExp { " << exp.joinName << ", ";
+  out_ << "JumpExp { " << table_.lookup(exp.joinName) << ", ";
   print_optional(table_, out_, exp.slotValue);
   out_ << " }";
 }
 
 void PrintExpVisitor::operator()(const AppExp &exp) {
-  out_ << "AppExp { " << exp.name << ", " << exp.funName << ", ";
+  out_ << "AppExp { " << table_.lookup(exp.name) << ", "
+       << table_.lookup(exp.funName) << ", ";
   print_vector(table_, out_, exp.paramValues);
   out_ << ", ";
   print(table_, out_, *exp.rest);
@@ -161,7 +162,7 @@ void PrintExpVisitor::operator()(const AppExp &exp) {
 
 void PrintExpVisitor::operator()(const BopExp &exp) {
   std::string bop = binOpString(exp.bop);
-  out_ << "BopExp { " << exp.name << ", " << bop << ", ";
+  out_ << "BopExp { " << table_.lookup(exp.name) << ", " << bop << ", ";
   print(table_, out_, exp.param1);
   out_ << ", ";
   print(table_, out_, exp.param2);

--- a/test/anf.cpp
+++ b/test/anf.cpp
@@ -7,40 +7,47 @@ namespace lambcalc {
 using namespace ast;
 
 TEST(AnfConversion, BinaryOperators) {
+  SymbolTable table;
   auto expr = make(BopExp{
       Bop::Plus, make(BopExp{Bop::Times, make(IntExp{2}), make(IntExp{3})}),
       make(IntExp{4})});
-  auto anf = anf::convert(*expr);
+  auto anf = anf::convert(table, *expr);
   std::string expected = "BopExp { tmp0, *, 2, 3, BopExp { tmp1, +, tmp0, 4, "
                          "HaltExp { tmp1 } } }";
-  EXPECT_EQ(anf->dump(), expected);
+  EXPECT_EQ(anf->dump(table), expected);
 }
 
 TEST(AnfConversion, LamApp) {
-  auto expr =
-      make(AppExp{make(LamExp{"x", make(BopExp{Bop::Plus, make(VarExp{"x"}),
-                                               make(IntExp{1})})}),
-                  make(IntExp{1})});
+  SymbolTable table;
+  auto expr = make(
+      AppExp{make(LamExp{table.lookup("x"),
+                         make(BopExp{Bop::Plus, make(VarExp{table.lookup("x")}),
+                                     make(IntExp{1})})}),
+             make(IntExp{1})});
   anf::resetCounter();
-  auto anf = anf::convert(*expr);
+  auto anf = anf::convert(table, *expr);
   std::string expected =
       "FunExp { tmp1, [x], BopExp { tmp0, +, x, 1, HaltExp { tmp0 } }, AppExp "
       "{ tmp2, tmp1, [1], HaltExp { tmp2 } } }";
-  EXPECT_EQ(anf->dump(), expected);
+  EXPECT_EQ(anf->dump(table), expected);
 }
 
 TEST(AnfConversion, IfElse) {
+  SymbolTable table;
   // (if (if (0 + 1) 0 1) ((fn f => f 1) (fn x => x + 1)) 0)
   auto expr = make(IfExp{
       make(IfExp{make(BopExp{Bop::Plus, make(IntExp{0}), make(IntExp{1})}),
                  make(IntExp{0}), make(IntExp{1})}),
       make(AppExp{
-          make(LamExp{"f", make(AppExp{make(VarExp{"f"}), make(IntExp{1})})}),
-          make(LamExp{"x", make(BopExp{Bop::Plus, make(VarExp{"x"}),
-                                       make(IntExp{1})})})}),
+          make(LamExp{
+              table.lookup("f"),
+              make(AppExp{make(VarExp{table.lookup("f")}), make(IntExp{1})})}),
+          make(LamExp{table.lookup("x"),
+                      make(BopExp{Bop::Plus, make(VarExp{table.lookup("x")}),
+                                  make(IntExp{1})})})}),
       make(IntExp{0})});
   anf::resetCounter();
-  auto anf = anf::convert(*expr);
+  auto anf = anf::convert(table, *expr);
   // let tmp0 = 0 + 1 in
   // let join tmp1 <tmp2> =
   //   let join tmp3 <tmp4> = tmp4 in
@@ -67,14 +74,15 @@ TEST(AnfConversion, IfElse) {
       "HaltExp { tmp7 } }, AppExp { tmp9, tmp6, [tmp8], JumpExp { tmp3, <tmp9> "
       "} } } }, JumpExp { tmp3, <0> } } }, IfExp { tmp0, JumpExp { tmp1, <0> "
       "}, JumpExp { tmp1, <1> } } } }";
-  EXPECT_EQ(anf->dump(), expected);
+  EXPECT_EQ(anf->dump(table), expected);
 
   anf::resetCounter();
-  auto anfDefunc = anf::convertDefunc(*expr);
-  EXPECT_EQ(anf->dump(), anfDefunc->dump());
+  auto anfDefunc = anf::convertDefunc(table, *expr);
+  EXPECT_EQ(anf->dump(table), anfDefunc->dump(table));
 }
 
 TEST(AnfConversion, NoStackOverflow) {
+  SymbolTable table;
   auto exp = make(IntExp{1});
   for (size_t i = 0; i < 2000; ++i) {
     exp = make(BopExp{Bop::Plus, make(IntExp{1}), std::move(exp)});
@@ -83,8 +91,8 @@ TEST(AnfConversion, NoStackOverflow) {
   // Modifying this to use anf::convert should lead to stack overflow, otherwise
   // increase the size of exp.
   anf::resetCounter();
-  auto anf = anf::convertDefunc(*exp);
-  EXPECT_EQ(anf->dump().size(), 67793);
+  auto anf = anf::convertDefunc(table, *exp);
+  EXPECT_EQ(anf->dump(table).size(), 67793);
 }
 
 } // namespace lambcalc

--- a/test/convert.cpp
+++ b/test/convert.cpp
@@ -7,35 +7,44 @@ namespace lambcalc {
 using namespace anf;
 
 TEST(FreeVars, Simple) {
-  auto exp = make(BopExp{"c", ast::Bop::Plus, VarValue{"a"}, VarValue{"b"},
-                         make(HaltExp{VarValue{"c"}})});
+  SymbolTable table;
+  auto exp = make(BopExp{
+      table.lookup("c"), ast::Bop::Plus, VarValue{table.lookup("a")},
+      VarValue{table.lookup("b")}, make(HaltExp{VarValue{table.lookup("c")}})});
   auto set = convert::freeVars(*exp);
   std::vector<Var> vars(set.begin(), set.end());
-  std::vector<Var> expected{"a", "b"};
+  std::vector<Var> expected{table.lookup("a"), table.lookup("b")};
   EXPECT_EQ(vars, expected);
 }
 
 TEST(FreeVars, FunJoin) {
-  auto exp = make(
-      FunExp{"f",
-             {"a", "b"},
-             make(JoinExp{
-                 "j",
-                 {"c"},
-                 make(TupleExp{
-                     "t",
-                     {VarValue{"b"}, VarValue{"c"}, VarValue{"d"}},
-                     make(ProjExp{"p", "t", 0, make(HaltExp{VarValue{"p"}})})}),
-                 make(BopExp{"x", ast::Bop::Plus, VarValue{"a"}, VarValue{"e"},
-                             make(JumpExp{"j", {GlobValue{"g"}}})})}),
-             make(HaltExp{VarValue{"f"}})});
+  SymbolTable table;
+  auto exp = make(FunExp{
+      table.lookup("f"),
+      {table.lookup("a"), table.lookup("b")},
+      make(JoinExp{
+          table.lookup("j"),
+          {table.lookup("c")},
+          make(TupleExp{
+              table.lookup("t"),
+              {VarValue{table.lookup("b")}, VarValue{table.lookup("c")},
+               VarValue{table.lookup("d")}},
+              make(ProjExp{table.lookup("p"), table.lookup("t"), 0,
+                           make(HaltExp{VarValue{table.lookup("p")}})})}),
+          make(BopExp{table.lookup("x"), ast::Bop::Plus,
+                      VarValue{table.lookup("a")}, VarValue{table.lookup("e")},
+                      make(JumpExp{table.lookup("j"),
+                                   {GlobValue{table.lookup("g")}}})})}),
+      make(HaltExp{VarValue{table.lookup("f")}})});
   auto set = convert::freeVars(*exp);
   std::vector<Var> vars(set.begin(), set.end());
-  std::vector<Var> expected{"d", "e", "g"};
+  std::vector<Var> expected{table.lookup("d"), table.lookup("e"),
+                            table.lookup("g")};
   EXPECT_EQ(vars, expected);
 }
 
 TEST(ClosureConvert, Simple) {
+  SymbolTable table;
   // let a = 1 + 2 in
   // let b = 3 * 4 in
   // let f = fn c d =>
@@ -47,23 +56,28 @@ TEST(ClosureConvert, Simple) {
   // let i = f 3 a in
   // i
   auto exp = make(BopExp{
-      "a", ast::Bop::Plus, IntValue{1}, IntValue{2},
+      table.lookup("a"), ast::Bop::Plus, IntValue{1}, IntValue{2},
       make(BopExp{
-          "b", ast::Bop::Times, IntValue{3}, IntValue{4},
+          table.lookup("b"), ast::Bop::Times, IntValue{3}, IntValue{4},
           make(FunExp{
-              "f",
-              {"c", "d"},
+              table.lookup("f"),
+              {table.lookup("c"), table.lookup("d")},
               make(BopExp{
-                  "e", ast::Bop::Plus, VarValue{"a"}, VarValue{"b"},
-                  make(BopExp{"g", ast::Bop::Plus, VarValue{"e"}, VarValue{"c"},
-                              make(BopExp{"h", ast::Bop::Times, VarValue{"g"},
-                                          VarValue{"d"},
-                                          make(HaltExp{VarValue{"h"}})})})}),
-              make(AppExp{"i",
-                          "f",
-                          {IntValue{3}, VarValue{"a"}},
-                          make(HaltExp{VarValue{"i"}})})})})});
-  auto convert = convert::closureConvert(std::move(exp));
+                  table.lookup("e"), ast::Bop::Plus,
+                  VarValue{table.lookup("a")}, VarValue{table.lookup("b")},
+                  make(BopExp{
+                      table.lookup("g"), ast::Bop::Plus,
+                      VarValue{table.lookup("e")}, VarValue{table.lookup("c")},
+                      make(BopExp{
+                          table.lookup("h"), ast::Bop::Times,
+                          VarValue{table.lookup("g")},
+                          VarValue{table.lookup("d")},
+                          make(HaltExp{VarValue{table.lookup("h")}})})})}),
+              make(AppExp{table.lookup("i"),
+                          table.lookup("f"),
+                          {IntValue{3}, VarValue{table.lookup("a")}},
+                          make(HaltExp{VarValue{table.lookup("i")}})})})})});
+  auto convert = convert::closureConvert(table, std::move(exp));
   // let a = 1 + 2 in
   // let b = 3 * 4 in
   // let f = fn closure0 c d =>
@@ -78,7 +92,7 @@ TEST(ClosureConvert, Simple) {
   // let proj1 = f[0] in
   // let i = proj1 f 3 a in
   // i
-  EXPECT_EQ(convert->dump(),
+  EXPECT_EQ(convert->dump(table),
             "BopExp { a, +, 1, 2, BopExp { b, *, 3, 4, FunExp { f, [closure0, "
             "c, d], ProjExp { b, closure0, 2, ProjExp { a, closure0, 1, BopExp "
             "{ e, +, a, b, BopExp { g, +, e, c, BopExp { h, *, g, d, HaltExp { "
@@ -87,6 +101,7 @@ TEST(ClosureConvert, Simple) {
 }
 
 TEST(ClosureConvert, Nested) {
+  SymbolTable table;
   // let f1 = fn a =>
   //   let f2 = fn b =>
   //     let r = a + b in
@@ -98,21 +113,24 @@ TEST(ClosureConvert, Nested) {
   // let t2 = t1 2 in
   // t2
   auto exp = make(FunExp{
-      "f1",
-      {"a"},
-      make(FunExp{"f2",
-                  {"b"},
-                  make(BopExp{"r", ast::Bop::Plus, VarValue{"a"}, VarValue{"b"},
-                              make(HaltExp{VarValue{"r"}})}),
-                  make(HaltExp{VarValue{"f2"}})}),
-      make(AppExp{
-          "t1",
-          "f1",
-          {IntValue{1}},
-          make(AppExp{
-              "t2", "t1", {IntValue{2}}, make(HaltExp{VarValue{"t2"}})})})});
-  auto convert = convert::closureConvert(std::move(exp));
-  EXPECT_EQ(convert->dump(),
+      table.lookup("f1"),
+      {table.lookup("a")},
+      make(FunExp{
+          table.lookup("f2"),
+          {table.lookup("b")},
+          make(BopExp{table.lookup("r"), ast::Bop::Plus,
+                      VarValue{table.lookup("a")}, VarValue{table.lookup("b")},
+                      make(HaltExp{VarValue{table.lookup("r")}})}),
+          make(HaltExp{VarValue{table.lookup("f2")}})}),
+      make(AppExp{table.lookup("t1"),
+                  table.lookup("f1"),
+                  {IntValue{1}},
+                  make(AppExp{table.lookup("t2"),
+                              table.lookup("t1"),
+                              {IntValue{2}},
+                              make(HaltExp{VarValue{table.lookup("t2")}})})})});
+  auto convert = convert::closureConvert(table, std::move(exp));
+  EXPECT_EQ(convert->dump(table),
             "FunExp { f1, [closure0, a], FunExp { f2, [closure3, b], ProjExp { "
             "a, closure3, 1, BopExp { r, +, a, b, HaltExp { r } } }, TupleExp "
             "{ f2, [f2, a], HaltExp { f2 } } }, TupleExp { f1, [f1], ProjExp { "

--- a/test/hoist.cpp
+++ b/test/hoist.cpp
@@ -6,6 +6,7 @@ namespace lambcalc {
 using namespace anf;
 
 TEST(Hoist, SimpleJoin) {
+  SymbolTable table;
   // let join a <x> =
   //   let join b <> = 0
   //   in
@@ -15,34 +16,36 @@ TEST(Hoist, SimpleJoin) {
   // let join c <> = 1 in
   // jump a 1
   auto exp = make(JoinExp{
-      "a",
-      {"x"},
-      make(JoinExp{"b",
+      table.lookup("a"),
+      {table.lookup("x")},
+      make(JoinExp{table.lookup("b"),
                    {},
                    make(HaltExp{IntValue{0}}),
-                   make(BopExp{"y", ast::Bop::Plus, VarValue{"x"}, IntValue{1},
-                               make(HaltExp{VarValue{"y"}})})}),
-      make(JoinExp{"c",
+                   make(BopExp{table.lookup("y"), ast::Bop::Plus,
+                               VarValue{table.lookup("x")}, IntValue{1},
+                               make(HaltExp{VarValue{table.lookup("y")}})})}),
+      make(JoinExp{table.lookup("c"),
                    {},
                    make(HaltExp{IntValue{1}}),
-                   make(JumpExp{"a", {IntValue{1}}})})});
-  auto collected = anf::hoist(std::move(exp));
+                   make(JumpExp{table.lookup("a"), {IntValue{1}}})})});
+  auto collected = anf::hoist(table, std::move(exp));
   EXPECT_EQ(collected.size(), static_cast<size_t>(1));
-  EXPECT_EQ(collected[0].entryBlock.body->dump(), "JumpExp { a, <1> }");
+  EXPECT_EQ(collected[0].entryBlock.body->dump(table), "JumpExp { a, <1> }");
   auto &blocks = collected[0].blocks;
   EXPECT_EQ(blocks.size(), static_cast<size_t>(3));
-  std::pair<std::string, std::string> tests[] = {
-      {"b", "HaltExp { 0 }"},
-      {"a", "BopExp { y, +, x, 1, HaltExp { y } }"},
-      {"c", "HaltExp { 1 }"},
+  std::pair<Symbol, std::string> tests[] = {
+      {table.lookup("b"), "HaltExp { 0 }"},
+      {table.lookup("a"), "BopExp { y, +, x, 1, HaltExp { y } }"},
+      {table.lookup("c"), "HaltExp { 1 }"},
   };
   for (size_t i = 0; i < blocks.size(); ++i) {
     EXPECT_EQ(blocks[i].name, std::get<0>(tests[i]));
-    EXPECT_EQ(blocks[i].body->dump(), std::get<1>(tests[i]));
+    EXPECT_EQ(blocks[i].body->dump(table), std::get<1>(tests[i]));
   }
 }
 
 TEST(Hoist, FunJoin) {
+  SymbolTable table;
   // let f1 = fn a =>
   //   let join j1 <> =
   //     let f2 = fn b =>
@@ -58,59 +61,67 @@ TEST(Hoist, FunJoin) {
   // let x = f1 0 in
   // x
   auto exp = make(FunExp{
-      "f1",
-      {"a"},
+      table.lookup("f1"),
+      {table.lookup("a")},
       make(JoinExp{
-          "j1",
+          table.lookup("j1"),
           {},
           make(FunExp{
-              "f2",
-              {"b"},
-              make(JoinExp{"j2",
-                           {"c"},
-                           make(HaltExp{VarValue{"c"}}),
-                           make(JumpExp{"j2", {IntValue{0}}})}),
-              make(AppExp{
-                  "y", "f2", {IntValue{1}}, make(HaltExp{VarValue{"y"}})})}),
-          make(JoinExp{
-              "j3", {}, make(JumpExp{"j1", {}}), make(JumpExp{"j3", {}})})}),
-      make(AppExp{"x", "f1", {IntValue{0}}, make(HaltExp{VarValue{"x"}})})});
-  auto collected = anf::hoist(std::move(exp));
+              table.lookup("f2"),
+              {table.lookup("b")},
+              make(JoinExp{table.lookup("j2"),
+                           {table.lookup("c")},
+                           make(HaltExp{VarValue{table.lookup("c")}}),
+                           make(JumpExp{table.lookup("j2"), {IntValue{0}}})}),
+              make(AppExp{table.lookup("y"),
+                          table.lookup("f2"),
+                          {IntValue{1}},
+                          make(HaltExp{VarValue{table.lookup("y")}})})}),
+          make(JoinExp{table.lookup("j3"),
+                       {},
+                       make(JumpExp{table.lookup("j1"), {}}),
+                       make(JumpExp{table.lookup("j3"), {}})})}),
+      make(AppExp{table.lookup("x"),
+                  table.lookup("f1"),
+                  {IntValue{0}},
+                  make(HaltExp{VarValue{table.lookup("x")}})})});
+  auto collected = anf::hoist(table, std::move(exp));
   EXPECT_EQ(collected.size(), static_cast<size_t>(3));
 
-  EXPECT_EQ(collected[0].name, "f2");
-  EXPECT_EQ(collected[0].entryBlock.body->dump(), "JumpExp { j2, <0> }");
+  EXPECT_EQ(table.lookup(collected[0].name), "f2");
+  EXPECT_EQ(collected[0].entryBlock.body->dump(table), "JumpExp { j2, <0> }");
   EXPECT_EQ(collected[0].blocks.size(), static_cast<size_t>(1));
-  EXPECT_EQ(collected[0].blocks[0].name, "j2");
-  EXPECT_EQ(collected[0].blocks[0].body->dump(), "HaltExp { c }");
+  EXPECT_EQ(table.lookup(collected[0].blocks[0].name), "j2");
+  EXPECT_EQ(collected[0].blocks[0].body->dump(table), "HaltExp { c }");
 
-  EXPECT_EQ(collected[1].name, "f1");
-  EXPECT_EQ(collected[1].entryBlock.body->dump(), "JumpExp { j3, <> }");
+  EXPECT_EQ(table.lookup(collected[1].name), "f1");
+  EXPECT_EQ(collected[1].entryBlock.body->dump(table), "JumpExp { j3, <> }");
   EXPECT_EQ(collected[1].blocks.size(), static_cast<size_t>(2));
-  std::pair<std::string, std::string> tests[] = {
-      {"j1", "AppExp { y, f2, [1], HaltExp { y } }"},
-      {"j3", "JumpExp { j1, <> }"},
+  std::pair<Symbol, std::string> tests[] = {
+      {table.lookup("j1"), "AppExp { y, f2, [1], HaltExp { y } }"},
+      {table.lookup("j3"), "JumpExp { j1, <> }"},
   };
   auto &blocks = collected[1].blocks;
   for (size_t i = 0; i < blocks.size(); ++i) {
     EXPECT_EQ(blocks[i].name, std::get<0>(tests[i]));
-    EXPECT_EQ(blocks[i].body->dump(), std::get<1>(tests[i]));
+    EXPECT_EQ(blocks[i].body->dump(table), std::get<1>(tests[i]));
   }
 
-  EXPECT_EQ(collected[2].name, "main");
-  EXPECT_EQ(collected[2].entryBlock.body->dump(),
+  EXPECT_EQ(table.lookup(collected[2].name), "main");
+  EXPECT_EQ(collected[2].entryBlock.body->dump(table),
             "AppExp { x, f1, [0], HaltExp { x } }");
   EXPECT_EQ(collected[2].blocks.size(), static_cast<size_t>(0));
 }
 
 TEST(Hoist, IfElse) {
-  auto exp =
-      make(IfExp{IntValue{1},
-                 make(IfExp{IntValue{0}, make(HaltExp{IntValue{2}}),
-                            make(HaltExp{IntValue{4}})}),
-                 make(BopExp{"a", ast::Bop::Plus, IntValue{1}, IntValue{2},
-                             make(HaltExp{VarValue{"a"}})})});
-  auto collected = anf::hoist(std::move(exp));
+  SymbolTable table;
+  auto exp = make(IfExp{
+      IntValue{1},
+      make(IfExp{IntValue{0}, make(HaltExp{IntValue{2}}),
+                 make(HaltExp{IntValue{4}})}),
+      make(BopExp{table.lookup("a"), ast::Bop::Plus, IntValue{1}, IntValue{2},
+                  make(HaltExp{VarValue{table.lookup("a")}})})});
+  auto collected = anf::hoist(table, std::move(exp));
   EXPECT_EQ(collected.size(), static_cast<size_t>(1));
   EXPECT_EQ(collected[0].blocks.size(), static_cast<size_t>(4));
 }

--- a/test/lexer.cpp
+++ b/test/lexer.cpp
@@ -5,8 +5,9 @@
 namespace lambcalc {
 
 TEST(Lexer, Tokens) {
+  SymbolTable table;
   std::istringstream is(" (fn a => a + 1 ) ( if 1  then  2 else  3)  ");
-  Lexer lexer(is);
+  Lexer lexer(table, is);
   std::vector<std::string> tokens;
   Token token;
   while ((token = lexer.getToken()) != Token::Eof) {
@@ -15,7 +16,7 @@ TEST(Lexer, Tokens) {
       tokens.push_back(std::to_string(lexer.getNumber()));
       break;
     case Token::Identifier:
-      tokens.emplace_back(lexer.getIdentifier());
+      tokens.emplace_back(table.lookup(lexer.getIdentifier()));
       break;
     case Token::Fn:
       tokens.emplace_back("fn");

--- a/test/lower.cpp
+++ b/test/lower.cpp
@@ -9,10 +9,12 @@ using namespace anf;
 using namespace llvm;
 
 TEST(Lower, Simple) {
-  auto exp = make(BopExp{"c", ast::Bop::Plus, IntValue{1}, IntValue{2},
-                         make(HaltExp{VarValue{"c"}})});
-  auto hoisted = anf::hoist(std::move(exp));
-  auto lowered = lower::lower(std::move(hoisted));
+  SymbolTable table;
+  auto exp =
+      make(BopExp{table.lookup("c"), ast::Bop::Plus, IntValue{1}, IntValue{2},
+                  make(HaltExp{VarValue{table.lookup("c")}})});
+  auto hoisted = anf::hoist(table, std::move(exp));
+  auto lowered = lower::lower(table, std::move(hoisted));
   std::ostringstream out;
   llvm::raw_os_ostream rout(out);
   lowered->print(rout, nullptr);
@@ -26,26 +28,34 @@ TEST(Lower, Simple) {
 }
 
 TEST(Lower, Functions) {
+  SymbolTable table;
   auto exp = make(FunExp{
-      "f1",
-      {"a"},
+      table.lookup("f1"),
+      {table.lookup("a")},
       make(JoinExp{
-          "j1",
+          table.lookup("j1"),
           {},
           make(FunExp{
-              "f2",
-              {"b"},
-              make(JoinExp{"j2",
-                           {"c"},
-                           make(HaltExp{VarValue{"c"}}),
-                           make(JumpExp{"j2", {IntValue{0}}})}),
-              make(AppExp{
-                  "y", "f2", {IntValue{1}}, make(HaltExp{VarValue{"y"}})})}),
-          make(JoinExp{
-              "j3", {}, make(JumpExp{"j1", {}}), make(JumpExp{"j3", {}})})}),
-      make(AppExp{"x", "f1", {IntValue{0}}, make(HaltExp{VarValue{"x"}})})});
-  auto hoisted = anf::hoist(std::move(exp));
-  auto lowered = lower::lower(std::move(hoisted));
+              table.lookup("f2"),
+              {table.lookup("b")},
+              make(JoinExp{table.lookup("j2"),
+                           {table.lookup("c")},
+                           make(HaltExp{VarValue{table.lookup("c")}}),
+                           make(JumpExp{table.lookup("j2"), {IntValue{0}}})}),
+              make(AppExp{table.lookup("y"),
+                          table.lookup("f2"),
+                          {IntValue{1}},
+                          make(HaltExp{VarValue{table.lookup("y")}})})}),
+          make(JoinExp{table.lookup("j3"),
+                       {},
+                       make(JumpExp{table.lookup("j1"), {}}),
+                       make(JumpExp{table.lookup("j3"), {}})})}),
+      make(AppExp{table.lookup("x"),
+                  table.lookup("f1"),
+                  {IntValue{0}},
+                  make(HaltExp{VarValue{table.lookup("x")}})})});
+  auto hoisted = anf::hoist(table, std::move(exp));
+  auto lowered = lower::lower(table, std::move(hoisted));
   std::ostringstream out;
   llvm::raw_os_ostream rout(out);
   lowered->print(rout, nullptr);
@@ -85,28 +95,31 @@ TEST(Lower, Functions) {
 }
 
 TEST(Lower, IfElse) {
+  SymbolTable table;
   auto exp = make(FunExp{
-      "f",
-      {"closure", "x"},
+      table.lookup("f"),
+      {table.lookup("closure"), table.lookup("x")},
       make(BopExp{
-          "a", ast::Bop::Plus, IntValue{1}, IntValue{2},
+          table.lookup("a"), ast::Bop::Plus, IntValue{1}, IntValue{2},
           make(IfExp{
-              VarValue{"a"},
-              make(IfExp{
-                  VarValue{"x"},
-                  make(BopExp{"c", ast::Bop::Plus, VarValue{"x"}, VarValue{"a"},
-                              make(AppExp{"d",
-                                          "f",
-                                          {VarValue{"c"}},
-                                          make(HaltExp{VarValue{"d"}})})}),
-                  make(HaltExp{IntValue{5}})}),
-              make(HaltExp{VarValue{"a"}})})}),
-      make(AppExp{"b",
-                  "f",
+              VarValue{table.lookup("a")},
+              make(IfExp{VarValue{table.lookup("x")},
+                         make(BopExp{table.lookup("c"), ast::Bop::Plus,
+                                     VarValue{table.lookup("x")},
+                                     VarValue{table.lookup("a")},
+                                     make(AppExp{table.lookup("d"),
+                                                 table.lookup("f"),
+                                                 {VarValue{table.lookup("c")}},
+                                                 make(HaltExp{VarValue{
+                                                     table.lookup("d")}})})}),
+                         make(HaltExp{IntValue{5}})}),
+              make(HaltExp{VarValue{table.lookup("a")}})})}),
+      make(AppExp{table.lookup("b"),
+                  table.lookup("f"),
                   {IntValue{0}, IntValue{1}}, // Pass 0 for closure for now.
-                  make(HaltExp{VarValue{"b"}})})});
-  auto hoisted = anf::hoist(std::move(exp));
-  auto lowered = lower::lower(std::move(hoisted));
+                  make(HaltExp{VarValue{table.lookup("b")}})})});
+  auto hoisted = anf::hoist(table, std::move(exp));
+  auto lowered = lower::lower(table, std::move(hoisted));
   std::ostringstream out;
   llvm::raw_os_ostream rout(out);
   lowered->print(rout, nullptr);
@@ -146,6 +159,7 @@ TEST(Lower, IfElse) {
 }
 
 TEST(Lower, AppClosure) {
+  SymbolTable table;
   // (fn g => (fn x => g x) (fn y => g y))
   // let f1 = fn g =>
   //   let f2 = fn x =>
@@ -161,24 +175,28 @@ TEST(Lower, AppClosure) {
   // in
   // f1
   auto exp = make(FunExp{
-      "f1",
-      {"g"},
+      table.lookup("f1"),
+      {table.lookup("g")},
       make(FunExp{
-          "f2",
-          {"x"},
-          make(AppExp{
-              "t1", "g", {VarValue{"x"}}, make(HaltExp{VarValue{"t1"}})}),
+          table.lookup("f2"),
+          {table.lookup("x")},
+          make(AppExp{table.lookup("t1"),
+                      table.lookup("g"),
+                      {VarValue{table.lookup("x")}},
+                      make(HaltExp{VarValue{table.lookup("t1")}})}),
           make(FunExp{
-              "f3",
-              {"y"},
-              make(AppExp{
-                  "t2", "g", {VarValue{"y"}}, make(HaltExp{VarValue{"t2"}})}),
-              make(AppExp{"t3",
-                          "f2",
-                          {VarValue{"f3"}},
-                          make(HaltExp{VarValue{"t3"}})})})}),
-      make(HaltExp{VarValue{"f1"}})});
-  auto converted = convert::closureConvert(std::move(exp));
+              table.lookup("f3"),
+              {table.lookup("y")},
+              make(AppExp{table.lookup("t2"),
+                          table.lookup("g"),
+                          {VarValue{table.lookup("y")}},
+                          make(HaltExp{VarValue{table.lookup("t2")}})}),
+              make(AppExp{table.lookup("t3"),
+                          table.lookup("f2"),
+                          {VarValue{table.lookup("f3")}},
+                          make(HaltExp{VarValue{table.lookup("t3")}})})})}),
+      make(HaltExp{VarValue{table.lookup("f1")}})});
+  auto converted = convert::closureConvert(table, std::move(exp));
   std::string expectedANF =
       "FunExp { f1, [closure0, g], FunExp { f2, [closure1, x], ProjExp { g, "
       "closure1, 1, ProjExp { proj5, g, 0, AppExp { t1, proj5, [g, x], HaltExp "
@@ -187,10 +205,10 @@ TEST(Lower, AppClosure) {
       "g, 0, AppExp { t2, proj4, [g, y], HaltExp { t2 } } } } }, TupleExp { "
       "f3, [f3, f2, g], ProjExp { proj3, f2, 0, AppExp { t3, proj3, [f2, f3], "
       "HaltExp { t3 } } } } } } }, TupleExp { f1, [f1], HaltExp { f1 } } }";
-  EXPECT_EQ(converted->dump(), expectedANF);
+  EXPECT_EQ(converted->dump(table), expectedANF);
 
-  auto hoisted = anf::hoist(std::move(converted));
-  auto lowered = lower::lower(std::move(hoisted));
+  auto hoisted = anf::hoist(table, std::move(converted));
+  auto lowered = lower::lower(table, std::move(hoisted));
   std::ostringstream out;
   llvm::raw_os_ostream rout(out);
   lowered->print(rout, nullptr);

--- a/test/parser.cpp
+++ b/test/parser.cpp
@@ -1,4 +1,5 @@
 #include "parser.h"
+#include "symbol.h"
 #include <gtest/gtest.h>
 #include <sstream>
 
@@ -10,48 +11,52 @@ const std::unordered_map<ast::Bop, std::optional<std::pair<int, int>>>
                    {ast::Bop::Times, {{3, 4}}}};
 
 TEST(Parser, ParsesOperators) {
+  SymbolTable table;
   std::istringstream is(" (fn a => a + 1 + 2 * 3 * 4 + 5 ) ");
   std::allocator<ast::Exp<>> allocator;
-  Lexer lexer(is);
+  Lexer lexer(table, is);
   Parser parser(allocator, lexer, defaultInfixBp);
   auto exp = parser.parseExpression();
   std::string expected = "(fn a => (((a + 1) + ((2 * 3) * 4)) + 5))";
-  EXPECT_EQ(exp->dump(), expected);
+  EXPECT_EQ(exp->dump(table), expected);
 }
 
 TEST(Parser, ParsesApp) {
+  SymbolTable table;
   std::istringstream is("a b c + d e f");
   std::allocator<ast::Exp<>> allocator;
-  Lexer lexer(is);
+  Lexer lexer(table, is);
   Parser parser(allocator, lexer, defaultInfixBp);
   auto exp = parser.parseExpression();
   std::string expected = "(((a b) c) + ((d e) f))";
-  EXPECT_EQ(exp->dump(), expected);
+  EXPECT_EQ(exp->dump(table), expected);
 }
 
 TEST(Parser, ParseIfWithAppParens) {
+  SymbolTable table;
   std::istringstream is("if x then x * f (x - 1) else 1");
   std::allocator<ast::Exp<>> allocator;
-  Lexer lexer(is);
+  Lexer lexer(table, is);
   Parser parser(allocator, lexer, defaultInfixBp);
   auto exp = parser.parseExpression();
   std::string expected = "(if x then (x * (f (x - 1))) else 1)";
-  EXPECT_EQ(exp->dump(), expected);
+  EXPECT_EQ(exp->dump(table), expected);
 }
 
 TEST(Parser, ZCombinator) {
+  SymbolTable table;
   std::istringstream is(
       "(fn g => (fn x => g (fn v => x x v)) (fn x => g (fn v => x x v))) (fn f "
       "=> fn x => if x then (if x - 1 then x * f (x - 1) else 1) else 1) 5");
   std::allocator<ast::Exp<>> allocator;
-  Lexer lexer(is);
+  Lexer lexer(table, is);
   Parser parser(allocator, lexer, defaultInfixBp);
   auto exp = parser.parseExpression();
   std::string expected =
       "(((fn g => ((fn x => (g (fn v => ((x x) v)))) (fn x => (g (fn v => ((x "
       "x) v)))))) (fn f => (fn x => (if x then (if (x - 1) then (x * (f (x - "
       "1))) else 1) else 1)))) 5)";
-  EXPECT_EQ(exp->dump(), expected);
+  EXPECT_EQ(exp->dump(table), expected);
 }
 
 } // namespace lambcalc

--- a/test/rename.cpp
+++ b/test/rename.cpp
@@ -6,44 +6,53 @@ namespace lambcalc {
 using namespace ast;
 
 TEST(AlphaRename, Simple) {
+  SymbolTable table;
   // (fn a => (fn b => b + 1) 1 + (fn b => b + 1) 2) 3
   auto exp = make(AppExp{
       make(LamExp{
-          "a", make(BopExp{
-                   Bop::Plus,
-                   make(AppExp{make(LamExp{"b", make(BopExp{Bop::Plus,
-                                                            make(VarExp{"b"}),
-                                                            make(IntExp{1})})}),
-                               make(IntExp{1})}),
-                   make(AppExp{make(LamExp{"b", make(BopExp{Bop::Plus,
-                                                            make(VarExp{"b"}),
-                                                            make(IntExp{1})})}),
-                               make(IntExp{2})})})}),
+          table.lookup("a"),
+          make(BopExp{
+              Bop::Plus,
+              make(AppExp{
+                  make(LamExp{
+                      table.lookup("b"),
+                      make(BopExp{Bop::Plus, make(VarExp{table.lookup("b")}),
+                                  make(IntExp{1})})}),
+                  make(IntExp{1})}),
+              make(AppExp{
+                  make(LamExp{
+                      table.lookup("b"),
+                      make(BopExp{Bop::Plus, make(VarExp{table.lookup("b")}),
+                                  make(IntExp{1})})}),
+                  make(IntExp{2})})})}),
       make(IntExp{3})});
-  rename(*exp);
+  rename(table, *exp);
   std::string expected =
       "((fn a0 => (((fn b2 => (b2 + 1)) 1) + ((fn b1 => (b1 + 1)) 2))) 3)";
-  EXPECT_EQ(exp->dump(), expected);
+  EXPECT_EQ(exp->dump(table), expected);
 }
 
 TEST(AlphaRename, RestoresBindingOnLamExit) {
+  SymbolTable table;
   // (fn a => (a + (fn a => a + 1) 1) + a) 2
   auto exp = make(AppExp{
       make(LamExp{
-          "a",
+          table.lookup("a"),
           make(BopExp{
               Bop::Plus,
               make(BopExp{
-                  Bop::Plus, make(VarExp{"a"}),
+                  Bop::Plus, make(VarExp{table.lookup("a")}),
                   make(AppExp{
-                      make(LamExp{"a", make(BopExp{Bop::Plus, make(VarExp{"a"}),
-                                                   make(IntExp{1})})}),
+                      make(LamExp{table.lookup("a"),
+                                  make(BopExp{Bop::Plus,
+                                              make(VarExp{table.lookup("a")}),
+                                              make(IntExp{1})})}),
                       make(IntExp{1})})}),
-              make(VarExp{"a"})})}),
+              make(VarExp{table.lookup("a")})})}),
       make(IntExp{2})});
-  rename(*exp);
+  rename(table, *exp);
   std::string expected = "((fn a0 => ((a0 + ((fn a1 => (a1 + 1)) 1)) + a0)) 2)";
-  EXPECT_EQ(exp->dump(), expected);
+  EXPECT_EQ(exp->dump(table), expected);
 }
 
 } // namespace lambcalc


### PR DESCRIPTION
Adds symbol table mapping strings to size_t indexes and refactors printing functions and unit tests to work with this change.